### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Keep GitHub Actions up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
## Summary
- Adds Dependabot to keep GitHub Actions dependencies up to date
- Weekly check schedule
- Auto-creates PRs when action updates are available

## Note
Dependabot for C++ monitors GitHub Actions versions only (not CMake/system dependencies like Boost, libxml2, OpenSSL which are managed by system package managers).