### PR TITLE
Add cppcheck static analysis to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,16 @@ jobs:
 
     - name: Test
       run: ctest --test-dir build --output-on-failure
+
+  cppcheck:
+    name: cppcheck
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Install cppcheck
+      run: sudo apt-get update && sudo apt-get install -y cppcheck
+
+    - name: Run cppcheck
+      run: cppcheck --enable=warning,style,performance --suppress=missingIncludeSystem libiqxmlrpc/


### PR DESCRIPTION
## Summary
- Adds cppcheck job to CI workflow
- Checks libiqxmlrpc/ for warnings, style, and performance issues
- Fails build if issues found

## Checks enabled
- warning
- style
- performance