### PR TITLE
Add ASan/UBSan sanitizers to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,36 @@ jobs:
     - name: Test
       run: ctest --test-dir build --output-on-failure
 
+  sanitizers:
+    name: ASan/UBSan
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: sudo apt-get update && sudo apt-get install -y clang libboost-dev libboost-date-time-dev libboost-thread-dev libboost-test-dev libboost-program-options-dev libxml2-dev libssl-dev
+
+    - name: Configure
+      run: |
+        mkdir build && cd build
+        cmake -Dbuild_tests=ON \
+          -DCMAKE_C_COMPILER=clang \
+          -DCMAKE_CXX_COMPILER=clang++ \
+          -DCMAKE_CXX_FLAGS="-DBOOST_TIMER_ENABLE_DEPRECATED -fsanitize=address,undefined -fno-omit-frame-pointer" \
+          -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined" \
+          -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address,undefined" \
+          ..
+
+    - name: Build
+      run: cmake --build build
+
+    - name: Test
+      run: ctest --test-dir build --output-on-failure
+      env:
+        ASAN_OPTIONS: detect_leaks=1:abort_on_error=1
+        UBSAN_OPTIONS: print_stacktrace=1:abort_on_error=1
+
   cppcheck:
     name: cppcheck
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds AddressSanitizer (ASan) and UndefinedBehaviorSanitizer (UBSan) job to CI
- Uses Clang on Ubuntu 24.04
- Runs tests with sanitizers enabled to detect memory errors and undefined behavior

## Configuration
- `ASAN_OPTIONS`: detect_leaks=1, abort_on_error=1
- `UBSAN_OPTIONS`: print_stacktrace=1, abort_on_error=1