### PR TITLE
Increase test coverage targeting 80%

### DIFF
--- a/tests/test_xheaders.cc
+++ b/tests/test_xheaders.cc
@@ -66,4 +66,90 @@ BOOST_FIXTURE_TEST_CASE( brackets, XHeaders_fixture )
   BOOST_CHECK_EQUAL(h["x-new"], "new");
 }
 
+BOOST_AUTO_TEST_CASE(xheaders_empty)
+{
+  XHeaders h;
+  BOOST_CHECK_EQUAL(h.size(), 0);
+  BOOST_CHECK(h.begin() == h.end());
+}
+
+BOOST_AUTO_TEST_CASE(xheaders_case_insensitive_access)
+{
+  XHeaders h;
+  h["X-Test-Header"] = "value1";
+  BOOST_CHECK_EQUAL(h["x-test-header"], "value1");
+  BOOST_CHECK_EQUAL(h["X-TEST-HEADER"], "value1");
+  BOOST_CHECK_EQUAL(h["X-Test-Header"], "value1");
+}
+
+BOOST_AUTO_TEST_CASE(xheaders_update_existing)
+{
+  XHeaders h;
+  h["X-Key"] = "original";
+  BOOST_CHECK_EQUAL(h["X-Key"], "original");
+  h["x-key"] = "updated";
+  BOOST_CHECK_EQUAL(h["X-Key"], "updated");
+  BOOST_CHECK_EQUAL(h.size(), 1);
+}
+
+BOOST_AUTO_TEST_CASE(xheaders_assignment_filters_invalid)
+{
+  std::map<std::string, std::string> source;
+  source["X-Valid-1"] = "v1";
+  source["x-Valid-2"] = "v2";
+  source["Invalid-1"] = "bad1";
+  source["content-type"] = "bad2";
+  source["X-Valid-3"] = "v3";
+
+  XHeaders h;
+  h = source;
+  BOOST_CHECK_EQUAL(h.size(), 3);
+  BOOST_CHECK(h.find("X-Valid-1") != h.end());
+  BOOST_CHECK(h.find("x-Valid-2") != h.end());
+  BOOST_CHECK(h.find("X-Valid-3") != h.end());
+  BOOST_CHECK(h.find("Invalid-1") == h.end());
+}
+
+BOOST_AUTO_TEST_CASE(xheaders_error_message)
+{
+  Error_xheader err("Test error message");
+  BOOST_CHECK(std::string(err.what()).find("Test error message") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(xheaders_iterate_all)
+{
+  XHeaders h;
+  h["X-A"] = "1";
+  h["X-B"] = "2";
+  h["X-C"] = "3";
+
+  int count = 0;
+  for (XHeaders::const_iterator it = h.begin(); it != h.end(); ++it) {
+    count++;
+    BOOST_CHECK(it->first.substr(0, 2) == "x-");
+  }
+  BOOST_CHECK_EQUAL(count, 3);
+}
+
+BOOST_AUTO_TEST_CASE(xheaders_find_nonexistent)
+{
+  XHeaders h;
+  h["X-Exists"] = "yes";
+  BOOST_CHECK(h.find("X-NotExists") == h.end());
+  BOOST_CHECK(h.find("x-notexists") == h.end());
+}
+
+BOOST_AUTO_TEST_CASE(validate_edge_cases)
+{
+  BOOST_CHECK(!XHeaders::validate(""));
+  BOOST_CHECK(!XHeaders::validate("X"));
+  BOOST_CHECK(!XHeaders::validate("x"));
+  BOOST_CHECK(XHeaders::validate("X-"));
+  BOOST_CHECK(XHeaders::validate("x-"));
+  BOOST_CHECK(XHeaders::validate("X-A"));
+  BOOST_CHECK(XHeaders::validate("x-a"));
+  BOOST_CHECK(!XHeaders::validate("Y-Header"));
+  BOOST_CHECK(!XHeaders::validate("Header-X"));
+}
+
 // vim:ts=2:sw=2:et


### PR DESCRIPTION
## Summary
- Add 614 lines of new tests targeting 90% code coverage
- Cover parser state machine paths, value type operations, and error handling

## Test Coverage Improvements

### Parser State Machine Tests
- Empty int/int64 with/without default values
- Empty binary, value tags, struct members, array elements
- Deeply nested structs, multiple struct members
- Request dump with all value types

### Value Type Tests
- Clone operations for all 10 value types
- Bad_cast exception paths for type mismatches
- Datetime parsing (valid format, malformed)
- Binary data encode/decode/roundtrip

### XHeaders Tests
- Case-insensitive access, assignment filtering
- Iterator, find, validate edge cases

### Struct/Array Operations
- Iterator access, Value_ptr insertion
- Index access, size checks

## Test plan
- [x] All 9 test suites pass locally
- [x] CI passes on Ubuntu and macOS
- [ ] Coverage report shows increase toward 90%