### PR TITLE
Optimize performance for large XML payloads

### DIFF
--- a/libiqxmlrpc/request.cc
+++ b/libiqxmlrpc/request.cc
@@ -1,8 +1,6 @@
 //  Libiqxmlrpc - an object-oriented XML-RPC solution.
 //  Copyright (C) 2011 Anton Dedov
 
-#include <boost/foreach.hpp>
-
 #include "request.h"
 #include "request_parser.h"
 
@@ -35,7 +33,7 @@ dump_request(const Request& request)
 
   {
     XmlBuilder::Node params(writer, "params");
-    BOOST_FOREACH(const Value& v, request.get_params()) {
+    for (const Value& v : request.get_params()) {
       XmlBuilder::Node param(writer, "param");
       value_to_xml(writer, v);
     }

--- a/libiqxmlrpc/value_type.h
+++ b/libiqxmlrpc/value_type.h
@@ -110,10 +110,12 @@ private:
 
 public:
   Array( const Array& );
+  Array( Array&& other ) noexcept : values(std::move(other.values)) {}
   Array() {}
   ~Array();
 
   Array& operator =( const Array& );
+  Array& operator =( Array&& other ) noexcept { swap(other); return *this; }
 
   void swap(Array&) throw();
   Array* clone() const;
@@ -231,10 +233,12 @@ public:
   typedef Value_stor::iterator iterator;
 
   Struct( const Struct& );
+  Struct( Struct&& other ) noexcept : values(std::move(other.values)) {}
   Struct() {}
   ~Struct();
 
   Struct& operator =( const Struct& );
+  Struct& operator =( Struct&& other ) noexcept { swap(other); return *this; }
 
   void swap(Struct&) throw();
   Struct* clone() const;
@@ -306,7 +310,7 @@ private:
   void encode() const;
 
   char get_idx( char );
-  void decode_four( const std::string& );
+  void decode_four( const char* four );
   void decode();
 };
 

--- a/tests/test_value_types_extended.cc
+++ b/tests/test_value_types_extended.cc
@@ -1057,6 +1057,52 @@ BOOST_AUTO_TEST_CASE(struct_find_missing_returns_end)
     BOOST_CHECK(s.find("missing") == s.end());
 }
 
+BOOST_AUTO_TEST_CASE(struct_move_constructor)
+{
+    Struct a;
+    a.insert("x", Value(10));
+    a.insert("y", Value(20));
+    a.insert("z", Value(30));
+
+    Struct b(std::move(a));
+
+    // Moved-to struct should have the values
+    BOOST_CHECK_EQUAL(b.size(), 3u);
+    BOOST_CHECK(b.has_field("x"));
+    BOOST_CHECK(b.has_field("y"));
+    BOOST_CHECK(b.has_field("z"));
+    BOOST_CHECK_EQUAL(b["x"].get_int(), 10);
+    BOOST_CHECK_EQUAL(b["y"].get_int(), 20);
+    BOOST_CHECK_EQUAL(b["z"].get_int(), 30);
+
+    // Moved-from struct should be empty
+    BOOST_CHECK_EQUAL(a.size(), 0u);
+}
+
+BOOST_AUTO_TEST_CASE(struct_move_assignment)
+{
+    Struct a;
+    a.insert("key1", Value(100));
+    a.insert("key2", Value(200));
+
+    Struct b;
+    b.insert("old", Value(999));
+
+    b = std::move(a);
+
+    // Moved-to struct should have the values from a
+    BOOST_CHECK_EQUAL(b.size(), 2u);
+    BOOST_CHECK(b.has_field("key1"));
+    BOOST_CHECK(b.has_field("key2"));
+    BOOST_CHECK_EQUAL(b["key1"].get_int(), 100);
+    BOOST_CHECK_EQUAL(b["key2"].get_int(), 200);
+
+    // Moved-from struct has the old values from b (swap semantics)
+    BOOST_CHECK_EQUAL(a.size(), 1u);
+    BOOST_CHECK(a.has_field("old"));
+    BOOST_CHECK_EQUAL(a["old"].get_int(), 999);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(array_operations_extended)
@@ -1096,6 +1142,46 @@ BOOST_AUTO_TEST_CASE(array_size_check)
 
     a.push_back(Value(2));
     BOOST_CHECK_EQUAL(a.size(), 2u);
+}
+
+BOOST_AUTO_TEST_CASE(array_move_constructor)
+{
+    Array a;
+    a.push_back(Value(1));
+    a.push_back(Value(2));
+    a.push_back(Value(3));
+
+    Array b(std::move(a));
+
+    // Moved-to array should have the values
+    BOOST_CHECK_EQUAL(b.size(), 3u);
+    BOOST_CHECK_EQUAL(b[0].get_int(), 1);
+    BOOST_CHECK_EQUAL(b[1].get_int(), 2);
+    BOOST_CHECK_EQUAL(b[2].get_int(), 3);
+
+    // Moved-from array should be empty
+    BOOST_CHECK_EQUAL(a.size(), 0u);
+}
+
+BOOST_AUTO_TEST_CASE(array_move_assignment)
+{
+    Array a;
+    a.push_back(Value(10));
+    a.push_back(Value(20));
+
+    Array b;
+    b.push_back(Value(100));
+
+    b = std::move(a);
+
+    // Moved-to array should have the values from a
+    BOOST_CHECK_EQUAL(b.size(), 2u);
+    BOOST_CHECK_EQUAL(b[0].get_int(), 10);
+    BOOST_CHECK_EQUAL(b[1].get_int(), 20);
+
+    // Moved-from array has the old values from b (swap semantics)
+    BOOST_CHECK_EQUAL(a.size(), 1u);
+    BOOST_CHECK_EQUAL(a[0].get_int(), 100);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

- Pre-allocate string capacity in base64 encode/decode to reduce reallocations
- Pre-allocate header dump string capacity
- Use direct string construction instead of `std::copy` with `back_inserter`
- Change `decode_four` signature from `const std::string&` to `const char*` to avoid ~250k heap allocations per 1MB of base64 input
- Add move constructors and assignment operators to `Array` and `Struct`

## Test plan

- [x] All existing tests pass (10 test suites)
- [x] Added 4 new tests for Array/Struct move semantics:
  - `array_move_constructor`
  - `array_move_assignment`
  - `struct_move_constructor`
  - `struct_move_assignment`