### PR TITLE
Fix remaining cppcheck style warnings

### DIFF
--- a/libiqxmlrpc/client.h
+++ b/libiqxmlrpc/client.h
@@ -89,7 +89,7 @@ public:
       \param uri  Requested URI (default "/RPC");
       \param vhost Requested virtual host (by default calculated form addr).
   */
-  Client(
+  explicit Client(
     const iqnet::Inet_addr& addr,
     const std::string& uri   = "/RPC",
     const std::string& vhost = ""

--- a/libiqxmlrpc/connection.cc
+++ b/libiqxmlrpc/connection.cc
@@ -20,11 +20,6 @@ Connection::~Connection()
 }
 
 
-void Connection::finish()
-{
-}
-
-
 size_t Connection::send( const char* data, size_t len )
 {
   return sock.send( data, len );

--- a/libiqxmlrpc/connection.h
+++ b/libiqxmlrpc/connection.h
@@ -24,9 +24,7 @@ protected:
 
 public:
   explicit Connection( const Socket& );
-  virtual ~Connection();
-
-  void finish() override;
+  ~Connection() override;
 
   virtual void post_accept() {}
   virtual void post_connect() {}

--- a/libiqxmlrpc/connector.cc
+++ b/libiqxmlrpc/connector.cc
@@ -16,18 +16,18 @@ struct Connect_processor: public Event_handler {
   Reactor_base& reactor;
   Socket sock;
 
-  Connect_processor(Reactor_base& r):
+  explicit Connect_processor(Reactor_base& r):
     reactor(r)
   {
     sock.set_non_blocking(true);
   }
 
-  Socket::Handler get_handler() const
+  Socket::Handler get_handler() const override
   {
     return sock.get_handler();
   }
 
-  void handle_output( bool& terminate )
+  void handle_output( bool& terminate ) override
   {
     terminate = true;
     int err = sock.get_last_error();

--- a/libiqxmlrpc/http.h
+++ b/libiqxmlrpc/http.h
@@ -129,7 +129,7 @@ class LIBIQXMLRPC_API Response_header: public Header {
 
 public:
   Response_header( Verification_level, const std::string& to_parse );
-  Response_header( int = 200, const std::string& = "OK" );
+  explicit Response_header( int = 200, const std::string& = "OK" );
 
   int code() const { return code_; }
   const std::string& phrase() const { return phrase_; }

--- a/libiqxmlrpc/lock.h
+++ b/libiqxmlrpc/lock.h
@@ -13,7 +13,7 @@ namespace iqnet
 class LIBIQXMLRPC_API Null_lock {
 public:
   struct scoped_lock {
-    scoped_lock(Null_lock&) {}
+    explicit scoped_lock(Null_lock&) {}
     ~scoped_lock() {}
 
     void lock() {}

--- a/libiqxmlrpc/net_except.h
+++ b/libiqxmlrpc/net_except.h
@@ -20,7 +20,7 @@ namespace iqnet
 //! Exception class to wrap a network's subsystem errors.
 class LIBIQXMLRPC_API network_error: public std::runtime_error {
 public:
-  network_error( const std::string& msg, bool use_errno = true, int myerrno = 0 );
+  explicit network_error( const std::string& msg, bool use_errno = true, int myerrno = 0 );
 };
 
 #ifdef _MSC_VER

--- a/libiqxmlrpc/reactor.h
+++ b/libiqxmlrpc/reactor.h
@@ -56,7 +56,7 @@ public:
     short           mask;
     short           revents;
 
-    HandlerState( Socket::Handler fd_ = 0 ):
+    explicit HandlerState( Socket::Handler fd_ = 0 ):
       fd(fd_), mask(0), revents(0) {}
 
     HandlerState( Socket::Handler fd_, Event_mask m ):

--- a/libiqxmlrpc/reactor_impl.h
+++ b/libiqxmlrpc/reactor_impl.h
@@ -284,7 +284,7 @@ bool Reactor<Lock>::handle_events(Reactor_base::Timeout ms)
   if (handlers.empty())
     return false;
 
-  if (handlers.size() - num_stoppers <= 0)
+  if (handlers.size() <= num_stoppers)
     throw No_handlers();
 
   handle_user_events();

--- a/libiqxmlrpc/util.h
+++ b/libiqxmlrpc/util.h
@@ -19,7 +19,7 @@ public:
   using argument_type = typename M::value_type;
   using result_type = typename M::mapped_type;
 
-  typename M::mapped_type operator ()(typename M::value_type& i)
+  typename M::mapped_type operator ()(const typename M::value_type& i)
   {
     return i.second;
   }
@@ -74,7 +74,7 @@ public:
   LockedBool(const LockedBool&) = delete;
   LockedBool& operator=(const LockedBool&) = delete;
 
-  LockedBool(bool default_):
+  explicit LockedBool(bool default_):
     val(default_) {}
 
   ~LockedBool() {}

--- a/libiqxmlrpc/xheaders.h
+++ b/libiqxmlrpc/xheaders.h
@@ -34,6 +34,6 @@ inline std::ostream& operator<<(std::ostream& os, const XHeaders& xheaders) {
 
 class LIBIQXMLRPC_API Error_xheader: public std::invalid_argument {
 public:
-  Error_xheader(const char* msg);
+  explicit Error_xheader(const char* msg);
 };
 }


### PR DESCRIPTION
## Summary
- Add `explicit` to single-argument constructors across multiple files to prevent implicit conversions
- Add `override` to virtual method overrides in `connector.cc`
- Fix `unsignedLessThanZero` warning in `reactor_impl.h` by changing subtraction comparison to direct comparison
- Remove useless `finish()` override in `connection.h` that just called base class empty implementation
- Fix `constParameterReference` in `util.h` Select2nd::operator()

## Test plan
- [x] Build passes locally
- [x] All unit tests pass (10/10)
- [ ] CI builds and tests pass
- [ ] cppcheck reports no style warnings