### PR TITLE
Fix cppcheck warnings for uninitialized members and missing copy semantics

### DIFF
--- a/libiqxmlrpc/client_conn.h
+++ b/libiqxmlrpc/client_conn.h
@@ -37,7 +37,7 @@ private:
   virtual std::string decorate_uri() const;
 
   http::Packet_reader preader;
-  const Client_options* options;
+  const Client_options* options = nullptr;
   std::vector<char> read_buf_;
 };
 

--- a/libiqxmlrpc/dispatcher_manager.cc
+++ b/libiqxmlrpc/dispatcher_manager.cc
@@ -91,6 +91,9 @@ private:
 
 class Method_dispatcher_manager::Impl {
 public:
+  Impl(const Impl&) = delete;
+  Impl& operator=(const Impl&) = delete;
+
   typedef std::deque<Method_dispatcher_base*> DispatchersSet;
   DispatchersSet dispatchers;
   Default_method_dispatcher* default_disp;

--- a/libiqxmlrpc/executor.h
+++ b/libiqxmlrpc/executor.h
@@ -51,6 +51,10 @@ struct Pool_executor_traits
 
 //! Abstract executor class. Defines the policy for method execution.
 class LIBIQXMLRPC_API Executor {
+public:
+  Executor(const Executor&) = delete;
+  Executor& operator=(const Executor&) = delete;
+
 protected:
   Method* method;
   Interceptor* interceptors;

--- a/libiqxmlrpc/http.h
+++ b/libiqxmlrpc/http.h
@@ -186,6 +186,9 @@ class Packet_reader {
   bool continue_sent_;
 
 public:
+  Packet_reader(const Packet_reader&) = delete;
+  Packet_reader& operator=(const Packet_reader&) = delete;
+
   Packet_reader():
     header(0),
     ver_level_(HTTP_CHECK_WEAK),

--- a/libiqxmlrpc/http_server.cc
+++ b/libiqxmlrpc/http_server.cc
@@ -16,7 +16,7 @@ class Http_server_connection:
   public iqnet::Connection,
   public Server_connection
 {
-  iqnet::Reactor_base* reactor;
+  iqnet::Reactor_base* reactor = nullptr;
 
 public:
   Http_server_connection( const iqnet::Socket& );

--- a/libiqxmlrpc/parser2.cc
+++ b/libiqxmlrpc/parser2.cc
@@ -126,7 +126,10 @@ public:
 
     ParseStep():
       done(false),
-      is_empty(false)
+      element_begin(false),
+      element_end(false),
+      is_empty(false),
+      is_text(false)
     {
     }
 

--- a/libiqxmlrpc/parser2.h
+++ b/libiqxmlrpc/parser2.h
@@ -123,7 +123,7 @@ private:
 
   const Parser& parser_;
   int curr_;
-  TransitionMap trans_;
+  TransitionMap trans_ = nullptr;
 };
 
 } // namespace iqxmlrpc

--- a/libiqxmlrpc/response.h
+++ b/libiqxmlrpc/response.h
@@ -42,7 +42,7 @@ public:
 
 private:
   std::shared_ptr<Value> value_;
-  int fault_code_;
+  int fault_code_ = 0;
   std::string fault_string_;
 };
 

--- a/libiqxmlrpc/response_parser.h
+++ b/libiqxmlrpc/response_parser.h
@@ -30,7 +30,7 @@ private:
 
   StateMachine state_;
   std::optional<Value> ok_;
-  int fault_code_;
+  int fault_code_ = 0;
   std::optional<std::string> fault_str_;
 };
 

--- a/libiqxmlrpc/ssl_connection.h
+++ b/libiqxmlrpc/ssl_connection.h
@@ -49,11 +49,11 @@ class LIBIQXMLRPC_API Reaction_connection: public ssl::Connection {
   Reactor_base* reactor;
 
   enum State { EMPTY, ACCEPTING, CONNECTING, READING, WRITING, SHUTDOWN };
-  State state;
+  State state = EMPTY;
 
-  char* recv_buf;
-  const char* send_buf;
-  size_t buf_len;
+  char* recv_buf = nullptr;
+  const char* send_buf = nullptr;
+  size_t buf_len = 0;
 
 public:
   Reaction_connection( const Socket&, Reactor_base* = 0 );

--- a/libiqxmlrpc/ssl_lib.cc
+++ b/libiqxmlrpc/ssl_lib.cc
@@ -183,7 +183,7 @@ ConnectionVerifier::cert_finger_sha256(X509_STORE_CTX* ctx) const
 //
 
 struct Ctx::Impl {
-  SSL_CTX* ctx;
+  SSL_CTX* ctx = nullptr;
   ConnectionVerifier* server_verifier;
   ConnectionVerifier* client_verifier;
   bool require_client_cert;

--- a/libiqxmlrpc/value_parser.cc
+++ b/libiqxmlrpc/value_parser.cc
@@ -17,6 +17,9 @@ namespace {
 
 class StructBuilder: public ValueBuilderBase {
 public:
+  StructBuilder(const StructBuilder&) = delete;
+  StructBuilder& operator=(const StructBuilder&) = delete;
+
   StructBuilder(Parser& parser):
     ValueBuilderBase(parser),
     state_(parser, NONE),
@@ -83,6 +86,9 @@ private:
 
 class ArrayBuilder: public ValueBuilderBase {
 public:
+  ArrayBuilder(const ArrayBuilder&) = delete;
+  ArrayBuilder& operator=(const ArrayBuilder&) = delete;
+
   ArrayBuilder(Parser& parser):
     ValueBuilderBase(parser),
     state_(parser, NONE),


### PR DESCRIPTION
## Summary
- Initialize all pointer members to nullptr and numeric members to 0/default values
- Add deleted copy constructor and assignment operator to classes with dynamic memory management

## Changes
| File | Fix |
|------|-----|
| client_conn.h | Initialize `options` pointer to nullptr |
| http_server.cc | Initialize `reactor` pointer to nullptr |
| http.h | Delete copy/assignment for `Packet_reader` |
| dispatcher_manager.cc | Delete copy/assignment for `Impl` |
| executor.h | Delete copy/assignment for `Executor` |
| parser2.cc | Initialize `ParseStep` boolean members |
| parser2.h | Initialize `StateMachine::trans_` to nullptr |
| response.h | Initialize `fault_code_` to 0 |
| response_parser.h | Initialize `fault_code_` to 0 |
| ssl_connection.h | Initialize `Reaction_connection` members |
| ssl_lib.cc | Initialize `Impl::ctx` to nullptr |
| value_parser.cc | Delete copy/assignment for `StructBuilder`/`ArrayBuilder` |

## Test plan
- [x] Build passes locally
- [x] All unit tests pass (10/10)
- [x] cppcheck reports no warnings
- [ ] CI builds and tests pass