### PR TITLE
Fix explicit/override style issues (safe subset)

### DIFF
--- a/libiqxmlrpc/acceptor.h
+++ b/libiqxmlrpc/acceptor.h
@@ -29,7 +29,7 @@ class LIBIQXMLRPC_API Acceptor: public Event_handler {
 
 public:
   Acceptor( const iqnet::Inet_addr& bind_addr, Accepted_conn_factory*, Reactor_base* );
-  virtual ~Acceptor();
+  ~Acceptor() override;
 
   void set_firewall( iqnet::Firewall_base* );
 

--- a/libiqxmlrpc/dispatcher_manager.cc
+++ b/libiqxmlrpc/dispatcher_manager.cc
@@ -20,16 +20,16 @@ class Default_method_dispatcher: public Method_dispatcher_base {
   Factory_map fs;
 
 public:
-  ~Default_method_dispatcher();
+  ~Default_method_dispatcher() override;
 
   void register_method(const std::string& name, Method_factory_base*);
 
 private:
-  virtual Method*
-  do_create_method(const std::string&);
+  Method*
+  do_create_method(const std::string&) override;
 
-  virtual void
-  do_get_methods_list(Array&) const;
+  void
+  do_get_methods_list(Array&) const override;
 };
 
 Default_method_dispatcher::~Default_method_dispatcher()
@@ -73,13 +73,13 @@ class System_method_factory: public Method_factory_base {
   Method_dispatcher_manager* dmgr_;
 
 public:
-  System_method_factory(Method_dispatcher_manager* dmgr):
+  explicit System_method_factory(Method_dispatcher_manager* dmgr):
     dmgr_(dmgr)
   {
   }
 
 private:
-  T* create()
+  T* create() override
   {
     return new T(dmgr_);
   }

--- a/libiqxmlrpc/executor.h
+++ b/libiqxmlrpc/executor.h
@@ -122,7 +122,7 @@ class LIBIQXMLRPC_API Pool_executor: public Executor {
 
 public:
   Pool_executor( Pool_executor_factory*, Method*, Server*, Server_connection* );
-  ~Pool_executor();
+  ~Pool_executor() override;
 
   void execute( const Param_list& ) override;
   void process_actual_execution();
@@ -146,7 +146,7 @@ class LIBIQXMLRPC_API Pool_executor_factory: public Executor_factory_base {
 
 public:
   explicit Pool_executor_factory(unsigned num_threads);
-  ~Pool_executor_factory();
+  ~Pool_executor_factory() override;
 
   Executor* create( Method* m, Server* s, Server_connection* c ) override;
   iqnet::Reactor_base* create_reactor() override;

--- a/libiqxmlrpc/http.h
+++ b/libiqxmlrpc/http.h
@@ -248,7 +248,7 @@ public:
     Packet( new Response_header(code, phrase), "" ),
     Exception( "HTTP: " + phrase ) {}
 
-  ~Error_response() throw() {};
+  ~Error_response() throw() override {};
 
   const Response_header* response_header() const
   {

--- a/libiqxmlrpc/http_server.cc
+++ b/libiqxmlrpc/http_server.cc
@@ -19,23 +19,23 @@ class Http_server_connection:
   iqnet::Reactor_base* reactor = nullptr;
 
 public:
-  Http_server_connection( const iqnet::Socket& );
+  explicit Http_server_connection( const iqnet::Socket& );
 
   void set_reactor( iqnet::Reactor_base* r ) { reactor = r; }
 
-  void post_accept();
-  void finish();
+  void post_accept() override;
+  void finish() override;
 
-  void handle_input( bool& );
-  void handle_output( bool& );
+  void handle_input( bool& ) override;
+  void handle_output( bool& ) override;
 
 
-  bool catch_in_reactor() const { return true; }
-  void log_exception( const std::exception& );
-  void log_unknown_exception();
+  bool catch_in_reactor() const override { return true; }
+  void log_exception( const std::exception& ) override;
+  void log_unknown_exception() override;
 
 private:
-  virtual void do_schedule_response();
+  void do_schedule_response() override;
 };
 
 typedef Server_conn_factory<Http_server_connection> Http_conn_factory;

--- a/libiqxmlrpc/https_client.cc
+++ b/libiqxmlrpc/https_client.cc
@@ -18,11 +18,11 @@ namespace iqxmlrpc {
 
 class LIBIQXMLRPC_API Proxy_request_header: public http::Header {
 public:
-  Proxy_request_header( const iqnet::Inet_addr& connect_addr ):
+  explicit Proxy_request_header( const iqnet::Inet_addr& connect_addr ):
     addr_(connect_addr) {}
 
 private:
-  virtual std::string dump_head() const
+  std::string dump_head() const override
   {
     return
       "CONNECT "

--- a/libiqxmlrpc/https_server.cc
+++ b/libiqxmlrpc/https_server.cc
@@ -17,21 +17,21 @@ class Https_server_connection:
   public iqxmlrpc::Server_connection
 {
 public:
-  Https_server_connection( const iqnet::Socket& );
+  explicit Https_server_connection( const iqnet::Socket& );
 
-  void post_accept() { Reaction_connection::post_accept(); }
-  void finish() { delete this; }
+  void post_accept() override { Reaction_connection::post_accept(); }
+  void finish() override { delete this; }
 
-  bool catch_in_reactor() const { return true; }
-  void log_exception( const std::exception& );
-  void log_unknown_exception();
+  bool catch_in_reactor() const override { return true; }
+  void log_exception( const std::exception& ) override;
+  void log_unknown_exception() override;
 
 protected:
   void my_reg_recv();
-  void accept_succeed();
-  void recv_succeed( bool& terminate, size_t req_len, size_t real_len );
-  void send_succeed( bool& terminate );
-  virtual void do_schedule_response();
+  void accept_succeed() override;
+  void recv_succeed( bool& terminate, size_t req_len, size_t real_len ) override;
+  void send_succeed( bool& terminate ) override;
+  void do_schedule_response() override;
 };
 
 typedef Server_conn_factory<Https_server_connection> Https_conn_factory;

--- a/libiqxmlrpc/inet_addr.cc
+++ b/libiqxmlrpc/inet_addr.cc
@@ -60,9 +60,9 @@ struct Inet_addr::Impl {
   std::string host;
   int port;
 
-  Impl( const SystemSockAddrIn& );
+  explicit Impl( const SystemSockAddrIn& );
   Impl( const std::string& host, int port );
-  Impl( int port );
+  explicit Impl( int port );
 
   void init_sockaddr() const;
 };

--- a/libiqxmlrpc/parser2.cc
+++ b/libiqxmlrpc/parser2.cc
@@ -99,7 +99,7 @@ BuilderBase::do_visit_text(const std::string&)
 
 class Parser::Impl {
 public:
-  Impl(const std::string& str):
+  explicit Impl(const std::string& str):
     buf(str),
     pushed_back(false)
   {

--- a/libiqxmlrpc/parser2.h
+++ b/libiqxmlrpc/parser2.h
@@ -80,7 +80,7 @@ protected:
 
 class Parser {
 public:
-  Parser(const std::string& buf);
+  explicit Parser(const std::string& buf);
 
   void
   parse(BuilderBase& builder);

--- a/libiqxmlrpc/reactor_impl.h
+++ b/libiqxmlrpc/reactor_impl.h
@@ -37,7 +37,7 @@ public:
   Reactor& operator=(const Reactor&) = delete;
 
   Reactor();
-  ~Reactor() {}
+  ~Reactor() override {}
 
   void register_handler( Event_handler*, Event_mask ) override;
   void unregister_handler( Event_handler*, Event_mask ) override;

--- a/libiqxmlrpc/reactor_interrupter.cc
+++ b/libiqxmlrpc/reactor_interrupter.cc
@@ -21,14 +21,14 @@ public:
     reactor_->register_handler(this, Reactor_base::INPUT);
   }
 
-  ~Interrupter_connection()
+  ~Interrupter_connection() override
   {
     reactor_->unregister_handler(this);
   }
 
-  bool is_stopper() const { return true; }
+  bool is_stopper() const override { return true; }
 
-  void handle_input(bool& /* terminate */)
+  void handle_input(bool& /* terminate */) override
   {
     char nothing;
     recv(&nothing, 1);
@@ -43,7 +43,7 @@ public:
   Impl(const Impl&) = delete;
   Impl& operator=(const Impl&) = delete;
 
-  Impl(Reactor_base* reactor);
+  explicit Impl(Reactor_base* reactor);
   ~Impl() {}
 
   void make_interrupt();

--- a/libiqxmlrpc/reactor_interrupter.h
+++ b/libiqxmlrpc/reactor_interrupter.h
@@ -18,7 +18,7 @@ public:
   Reactor_interrupter(const Reactor_interrupter&) = delete;
   Reactor_interrupter& operator=(const Reactor_interrupter&) = delete;
 
-  Reactor_interrupter(Reactor_base*);
+  explicit Reactor_interrupter(Reactor_base*);
   ~Reactor_interrupter();
 
   void make_interrupt();

--- a/libiqxmlrpc/request_parser.h
+++ b/libiqxmlrpc/request_parser.h
@@ -12,14 +12,14 @@ namespace iqxmlrpc {
 
 class RequestBuilder: public BuilderBase {
 public:
-  RequestBuilder(Parser&);
+  explicit RequestBuilder(Parser&);
 
   Request*
   get();
 
 private:
-  virtual void
-  do_visit_element(const std::string&);
+  void
+  do_visit_element(const std::string&) override;
 
   StateMachine state_;
   std::optional<std::string> method_name_;

--- a/libiqxmlrpc/response_parser.h
+++ b/libiqxmlrpc/response_parser.h
@@ -13,14 +13,14 @@ namespace iqxmlrpc {
 
 class ResponseBuilder: public BuilderBase {
 public:
-  ResponseBuilder(Parser&);
+  explicit ResponseBuilder(Parser&);
 
   Response
   get();
 
 private:
-  virtual void
-  do_visit_element(const std::string&);
+  void
+  do_visit_element(const std::string&) override;
 
   void
   parse_ok();

--- a/libiqxmlrpc/ssl_connection.h
+++ b/libiqxmlrpc/ssl_connection.h
@@ -22,7 +22,7 @@ protected:
 
 public:
   explicit Connection( const Socket& sock );
-  ~Connection();
+  ~Connection() override;
 
   void shutdown();
   size_t send( const char*, size_t ) override;

--- a/libiqxmlrpc/ssl_lib.h
+++ b/libiqxmlrpc/ssl_lib.h
@@ -80,7 +80,7 @@ class LIBIQXMLRPC_API exception: public std::exception {
 public:
   exception() throw();
   explicit exception( unsigned long ssl_err ) throw();
-  exception( const std::string& msg ) throw();
+  explicit exception( const std::string& msg ) throw();
   virtual ~exception() throw() {}
 
   const char*   what() const throw() { return msg.c_str(); }
@@ -96,7 +96,7 @@ public:
 class LIBIQXMLRPC_API connection_close: public ssl::exception {
   bool clean;
 public:
-  connection_close( bool clean_ ):
+  explicit connection_close( bool clean_ ):
     exception( "Connection has been closed." ),
     clean(clean_) {}
 
@@ -105,7 +105,7 @@ public:
 
 class LIBIQXMLRPC_API io_error: public ssl::exception {
 public:
-  io_error( int err ):
+  explicit io_error( int err ):
     exception( err ) {}
 };
 

--- a/libiqxmlrpc/value_parser.cc
+++ b/libiqxmlrpc/value_parser.cc
@@ -20,7 +20,7 @@ public:
   StructBuilder(const StructBuilder&) = delete;
   StructBuilder& operator=(const StructBuilder&) = delete;
 
-  StructBuilder(Parser& parser):
+  explicit StructBuilder(Parser& parser):
     ValueBuilderBase(parser),
     state_(parser, NONE),
     value_(0)
@@ -43,8 +43,8 @@ private:
     VALUE_READ,
   };
 
-  virtual void
-  do_visit_element(const std::string& tagname)
+  void
+  do_visit_element(const std::string& tagname) override
   {
     switch (state_.change(tagname)) {
     case NAME_READ:
@@ -64,8 +64,8 @@ private:
     }
   }
 
-  virtual void
-  do_visit_element_end(const std::string& tagname)
+  void
+  do_visit_element_end(const std::string& tagname) override
   {
     if (tagname == "member") {
       if (state_.get_state() != VALUE_READ) {
@@ -89,7 +89,7 @@ public:
   ArrayBuilder(const ArrayBuilder&) = delete;
   ArrayBuilder& operator=(const ArrayBuilder&) = delete;
 
-  ArrayBuilder(Parser& parser):
+  explicit ArrayBuilder(Parser& parser):
     ValueBuilderBase(parser),
     state_(parser, NONE),
     proxy_(0)
@@ -111,8 +111,8 @@ private:
     VALUES
   };
 
-  virtual void
-  do_visit_element(const std::string& tagname)
+  void
+  do_visit_element(const std::string& tagname) override
   {
     if (state_.change(tagname) == VALUES) {
       Value_type* tmp = sub_build<Value_type*, ValueBuilder>();

--- a/libiqxmlrpc/value_parser.h
+++ b/libiqxmlrpc/value_parser.h
@@ -13,7 +13,7 @@ namespace iqxmlrpc {
 
 class ValueBuilderBase: public BuilderBase {
 public:
-  ValueBuilderBase(Parser& parser, bool expect_text = false);
+  explicit ValueBuilderBase(Parser& parser, bool expect_text = false);
 
   Value_type*
   result()
@@ -27,17 +27,17 @@ protected:
 
 class ValueBuilder: public ValueBuilderBase {
 public:
-  ValueBuilder(Parser& parser);
+  explicit ValueBuilder(Parser& parser);
 
 private:
-  virtual void
-  do_visit_element(const std::string&);
+  void
+  do_visit_element(const std::string&) override;
 
-  virtual void
-  do_visit_element_end(const std::string&);
+  void
+  do_visit_element_end(const std::string&) override;
 
-  virtual void
-  do_visit_text(const std::string&);
+  void
+  do_visit_text(const std::string&) override;
 
   StateMachine state_;
 };

--- a/libiqxmlrpc/value_type.cc
+++ b/libiqxmlrpc/value_type.cc
@@ -114,7 +114,7 @@ class Array::Array_inserter {
   Array::Val_vector* vv;
 
 public:
-  Array_inserter( Array::Val_vector* v ): vv(v) {}
+  explicit Array_inserter( Array::Val_vector* v ): vv(v) {}
 
   void operator ()( const Value& v )
   {
@@ -203,7 +203,7 @@ class Struct::Struct_inserter
   Struct::Value_stor* vs;
 
 public:
-  Struct_inserter( Struct::Value_stor* v ): vs(v) {}
+  explicit Struct_inserter( Struct::Value_stor* v ): vs(v) {}
 
   void operator ()( const std::pair<std::string, Value*>& vp )
   {

--- a/libiqxmlrpc/value_type.h
+++ b/libiqxmlrpc/value_type.h
@@ -110,7 +110,7 @@ public:
   Array( const Array& );
   Array( Array&& other ) noexcept : values(std::move(other.values)) {}
   Array() {}
-  ~Array();
+  ~Array() override;
 
   Array& operator =( const Array& );
   Array& operator =( Array&& other ) noexcept { swap(other); return *this; }
@@ -233,7 +233,7 @@ public:
   Struct( const Struct& );
   Struct( Struct&& other ) noexcept : values(std::move(other.values)) {}
   Struct() {}
-  ~Struct();
+  ~Struct() override;
 
   Struct& operator =( const Struct& );
   Struct& operator =( Struct&& other ) noexcept { swap(other); return *this; }

--- a/libiqxmlrpc/value_type_visitor.h
+++ b/libiqxmlrpc/value_type_visitor.h
@@ -92,20 +92,20 @@ private:
 //! Value_type visitor that prints visited values recursively.
 class LIBIQXMLRPC_API Print_value_visitor: public Value_type_visitor {
 public:
-  Print_value_visitor(std::ostream&);
+  explicit Print_value_visitor(std::ostream&);
 
 private:
-  virtual void do_visit_value(const Value_type&);
-  virtual void do_visit_nil();
-  virtual void do_visit_int(int);
-  virtual void do_visit_int64(int64_t);
-  virtual void do_visit_double(double);
-  virtual void do_visit_bool(bool);
-  virtual void do_visit_string(const std::string&);
-  virtual void do_visit_struct(const Struct&);
-  virtual void do_visit_array(const Array&);
-  virtual void do_visit_base64(const Binary_data&);
-  virtual void do_visit_datetime(const Date_time&);
+  void do_visit_value(const Value_type&) override;
+  void do_visit_nil() override;
+  void do_visit_int(int) override;
+  void do_visit_int64(int64_t) override;
+  void do_visit_double(double) override;
+  void do_visit_bool(bool) override;
+  void do_visit_string(const std::string&) override;
+  void do_visit_struct(const Struct&) override;
+  void do_visit_array(const Array&) override;
+  void do_visit_base64(const Binary_data&) override;
+  void do_visit_datetime(const Date_time&) override;
 
   std::ostream& out_;
 };

--- a/libiqxmlrpc/value_type_xml.h
+++ b/libiqxmlrpc/value_type_xml.h
@@ -11,22 +11,22 @@ class XmlBuilder;
 //! Value_type visitor that converts values into XML-RPC representation.
 class Value_type_to_xml: public Value_type_visitor {
 public:
-  Value_type_to_xml(XmlBuilder& builder, bool server_mode = false):
+  explicit Value_type_to_xml(XmlBuilder& builder, bool server_mode = false):
     builder_(builder),
     server_mode_(server_mode) {}
 
 private:
-  virtual void do_visit_value(const Value_type&);
-  virtual void do_visit_nil();
-  virtual void do_visit_int(int);
-  virtual void do_visit_int64(int64_t);
-  virtual void do_visit_double(double);
-  virtual void do_visit_bool(bool);
-  virtual void do_visit_string(const std::string&);
-  virtual void do_visit_struct(const Struct&);
-  virtual void do_visit_array(const Array&);
-  virtual void do_visit_base64(const Binary_data&);
-  virtual void do_visit_datetime(const Date_time&);
+  void do_visit_value(const Value_type&) override;
+  void do_visit_nil() override;
+  void do_visit_int(int) override;
+  void do_visit_int64(int64_t) override;
+  void do_visit_double(double) override;
+  void do_visit_bool(bool) override;
+  void do_visit_string(const std::string&) override;
+  void do_visit_struct(const Struct&) override;
+  void do_visit_array(const Array&) override;
+  void do_visit_base64(const Binary_data&) override;
+  void do_visit_datetime(const Date_time&) override;
 
   void add_textnode(const char* name, const std::string& data);
 


### PR DESCRIPTION
## Summary
Fix cppcheck `noExplicitConstructor` and `missingOverride` style warnings for all internal classes while preserving API compatibility with the bss codebase.

## Changes

### Override specifiers added to:
- **Destructors**: `~Acceptor`, `~Array`, `~Struct`, `~Error_response`, `~Reactor`, `~Default_method_dispatcher`, `~Pool_executor`, `~Pool_executor_factory`, `~ssl::Connection`, `~Interrupter_connection`
- **Methods**: Virtual function overrides in `Http_server_connection`, `Https_server_connection`, `Proxy_request_header`, `Print_value_visitor`, `Value_type_to_xml`, `RequestBuilder`, `ResponseBuilder`, `ValueBuilder`, `StructBuilder`, `ArrayBuilder`, and internal classes

### Explicit constructors added to (internal classes):
- `System_method_factory`, `Http_server_connection`, `Https_server_connection`, `Proxy_request_header`
- SSL exceptions: `ssl::exception(string)`, `ssl::connection_close`, `ssl::io_error`
- `Reactor_interrupter`, `Parser`, `Parser::Impl`, `Inet_addr::Impl`
- Parsers: `RequestBuilder`, `ResponseBuilder`, `ValueBuilderBase`, `ValueBuilder`, `StructBuilder`, `ArrayBuilder`
- Visitors: `Print_value_visitor`, `Value_type_to_xml`
- Inserters: `Array_inserter`, `Struct_inserter`

### Intentionally NOT made explicit (API compatibility):
- All `Value` constructors (int, bool, double, string, char*, Binary_data, Date_time, Array, Struct, etc.)
- `Inet_addr(string, port)` constructor
- `Array::const_iterator` constructor

These are used with implicit conversions in ~/work/bss codebase (e.g., `param["key"] = 42`).

## Test plan
- [x] Build passes locally
- [x] All unit tests pass (10/10)
- [x] cppcheck reports only expected remaining issues (Value/Inet_addr/const_iterator)
- [ ] CI builds and tests pass