### PR TITLE
Add performance benchmarks for optimization baseline

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,3 +57,14 @@ add_custom_target(check ALL
 )
 
 # TODO: server-stop-test
+
+# Performance benchmark (separate from unit tests - run with make perf-test)
+add_executable(performance-test test_performance.cc)
+target_link_libraries(performance-test iqxmlrpc ${Boost_LIBRARIES} ${LIBXML2_LIBRARIES})
+
+add_custom_target(perf-test
+    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/performance-test
+    DEPENDS performance-test
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    COMMENT "Running performance benchmarks..."
+)

--- a/tests/perf_utils.h
+++ b/tests/perf_utils.h
@@ -1,0 +1,148 @@
+#ifndef IQXMLRPC_PERF_UTILS_H
+#define IQXMLRPC_PERF_UTILS_H
+
+#include <chrono>
+#include <string>
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <sstream>
+#include <vector>
+#include <ctime>
+
+namespace perf {
+
+// Result from a single benchmark
+struct BenchmarkResult {
+  std::string name;
+  double total_ms;
+  size_t iterations;
+  double ns_per_op;
+
+  BenchmarkResult(const std::string& n, double ms, size_t iters)
+    : name(n), total_ms(ms), iterations(iters)
+  {
+    ns_per_op = (ms * 1000000.0) / static_cast<double>(iters);
+  }
+};
+
+// Global collection of results
+class ResultCollector {
+  std::vector<BenchmarkResult> results_;
+  std::chrono::high_resolution_clock::time_point suite_start_;
+
+public:
+  static ResultCollector& instance() {
+    static ResultCollector inst;
+    return inst;
+  }
+
+  void start_suite() {
+    suite_start_ = std::chrono::high_resolution_clock::now();
+  }
+
+  void add_result(const BenchmarkResult& r) {
+    results_.push_back(r);
+
+    // Print to console
+    std::cout << "[PERF] " << std::setw(30) << std::left << r.name << ": "
+              << std::fixed << std::setprecision(3) << std::setw(10) << std::right << r.total_ms << " ms"
+              << " (" << r.iterations << " iters, "
+              << std::setprecision(2) << r.ns_per_op << " ns/op)"
+              << std::endl;
+  }
+
+  void save_baseline(const std::string& filename) {
+    auto suite_end = std::chrono::high_resolution_clock::now();
+    double total_time = std::chrono::duration<double>(suite_end - suite_start_).count();
+
+    std::ofstream out(filename);
+    if (!out) {
+      std::cerr << "Warning: Could not write to " << filename << std::endl;
+      return;
+    }
+
+    // Header
+    std::time_t now = std::time(nullptr);
+    char time_buf[64];
+    std::strftime(time_buf, sizeof(time_buf), "%Y-%m-%d %H:%M:%S", std::localtime(&now));
+
+    out << "# Performance Baseline - libiqxmlrpc2\n";
+    out << "# Run date: " << time_buf << "\n";
+    out << "# Total benchmarks: " << results_.size() << "\n";
+    out << "# Total time: " << std::fixed << std::setprecision(2) << total_time << " seconds\n";
+    out << "#\n";
+    out << "# Format: benchmark_name: ns_per_op\n";
+    out << "#\n";
+
+    for (const auto& r : results_) {
+      out << r.name << ": " << std::fixed << std::setprecision(2) << r.ns_per_op << "\n";
+    }
+
+    std::cout << "\n--- Summary ---\n";
+    std::cout << "Total benchmarks: " << results_.size() << "\n";
+    std::cout << "Total time: " << std::fixed << std::setprecision(2) << total_time << " seconds\n";
+    std::cout << "Results saved to: " << filename << "\n";
+  }
+
+  void clear() { results_.clear(); }
+
+private:
+  ResultCollector() = default;
+};
+
+// Timer class - measures elapsed time on destruction
+class Timer {
+  std::chrono::high_resolution_clock::time_point start_;
+  std::string name_;
+  size_t iterations_;
+  bool stopped_ = false;
+
+public:
+  Timer(const std::string& name, size_t iterations)
+    : start_(std::chrono::high_resolution_clock::now())
+    , name_(name)
+    , iterations_(iterations)
+  {}
+
+  ~Timer() {
+    if (!stopped_) stop();
+  }
+
+  void stop() {
+    if (stopped_) return;
+    stopped_ = true;
+
+    auto end = std::chrono::high_resolution_clock::now();
+    double ms = std::chrono::duration<double, std::milli>(end - start_).count();
+
+    ResultCollector::instance().add_result(BenchmarkResult(name_, ms, iterations_));
+  }
+};
+
+// Helper macro for running benchmarks with warmup
+#define PERF_BENCHMARK(name, iterations, code)                            \
+  do {                                                                    \
+    /* Warmup - 10% of iterations */                                      \
+    for (size_t i = 0; i < (iterations) / 10; ++i) { code; }              \
+    /* Actual benchmark */                                                \
+    {                                                                     \
+      perf::Timer timer(name, iterations);                                \
+      for (size_t i = 0; i < (iterations); ++i) { code; }                 \
+    }                                                                     \
+  } while (0)
+
+// Prevent compiler from optimizing away results
+template<typename T>
+inline void do_not_optimize(const T& value) {
+  asm volatile("" : : "r,m"(value) : "memory");
+}
+
+// Print section header
+inline void section(const std::string& name) {
+  std::cout << "\n--- " << name << " ---\n";
+}
+
+} // namespace perf
+
+#endif // IQXMLRPC_PERF_UTILS_H

--- a/tests/performance_baseline.txt
+++ b/tests/performance_baseline.txt
@@ -1,0 +1,38 @@
+# Performance Baseline - libiqxmlrpc2
+# Run date: 2026-01-09 19:10:00
+# Total benchmarks: 31
+# Total time: 3.11 seconds
+#
+# Format: benchmark_name: ns_per_op
+#
+perf_int_to_string: 82.38
+perf_string_to_int: 83.35
+perf_int64_to_string: 169.79
+perf_string_to_int64: 159.96
+perf_double_to_string: 282.67
+perf_string_to_double: 266.88
+perf_type_check_int_true: 7.46
+perf_type_check_int_false: 42.38
+perf_type_check_string_true: 7.83
+perf_type_check_mixed: 317.79
+perf_http_response_header: 8544.40
+perf_http_response_dump: 10161.35
+perf_datetime_parse: 776.80
+perf_datetime_to_string: 5.44
+perf_value_clone_int: 22.08
+perf_value_clone_string: 45.51
+perf_value_clone_array_10: 1161.69
+perf_value_clone_array_100: 6586.92
+perf_value_clone_array_1000: 56718.34
+perf_value_clone_struct_5: 2142.67
+perf_value_clone_struct_20: 12228.12
+perf_array_push_back: 8011.12
+perf_struct_insert: 11223.50
+perf_base64_encode_1kb: 6.98
+perf_base64_decode_1kb: 18098.26
+perf_base64_encode_64kb: 6.46
+perf_base64_decode_64kb: 970158.46
+perf_parse_response_10: 83640.75
+perf_parse_response_1000: 7763318.33
+perf_dump_response_10: 25340.38
+perf_dump_response_1000: 2434397.08

--- a/tests/test_performance.cc
+++ b/tests/test_performance.cc
@@ -1,0 +1,441 @@
+// Performance Benchmarks for libiqxmlrpc2
+// Measures baseline performance before optimizations
+// Run: make perf-test
+
+#include "perf_utils.h"
+
+#include "libiqxmlrpc/value.h"
+#include "libiqxmlrpc/value_type.h"
+#include "libiqxmlrpc/response.h"
+#include "libiqxmlrpc/response_parser.h"
+#include "libiqxmlrpc/http.h"
+
+#include <boost/lexical_cast.hpp>
+#include <string>
+#include <vector>
+#include <memory>
+#include <cstring>
+
+using namespace iqxmlrpc;
+
+// ============================================================================
+// A. Number Conversion Benchmarks (High Priority)
+// Target: boost::lexical_cast -> std::to_chars/from_chars
+// ============================================================================
+
+void benchmark_number_conversions() {
+  perf::section("Number Conversion (boost::lexical_cast)");
+
+  const size_t ITERS = 100000;
+
+  // int -> string
+  {
+    int val = 123456;
+    PERF_BENCHMARK("perf_int_to_string", ITERS, {
+      std::string s = boost::lexical_cast<std::string>(val);
+      perf::do_not_optimize(s);
+    });
+  }
+
+  // string -> int
+  PERF_BENCHMARK("perf_string_to_int", ITERS, {
+    std::string s = "123456";
+    int val = boost::lexical_cast<int>(s);
+    perf::do_not_optimize(val);
+  });
+
+  // int64_t -> string
+  {
+    int64_t val = 9223372036854775807LL;
+    PERF_BENCHMARK("perf_int64_to_string", ITERS, {
+      std::string s = boost::lexical_cast<std::string>(val);
+      perf::do_not_optimize(s);
+    });
+  }
+
+  // string -> int64_t
+  PERF_BENCHMARK("perf_string_to_int64", ITERS, {
+    std::string s = "9223372036854775807";
+    int64_t val = boost::lexical_cast<int64_t>(s);
+    perf::do_not_optimize(val);
+  });
+
+  // double -> string
+  {
+    double val = 3.141592653589793;
+    PERF_BENCHMARK("perf_double_to_string", ITERS, {
+      std::string s = boost::lexical_cast<std::string>(val);
+      perf::do_not_optimize(s);
+    });
+  }
+
+  // string -> double
+  PERF_BENCHMARK("perf_string_to_double", ITERS, {
+    std::string s = "3.141592653589793";
+    double val = boost::lexical_cast<double>(s);
+    perf::do_not_optimize(val);
+  });
+}
+
+// ============================================================================
+// B. Type Checking Benchmarks (Medium Priority)
+// Target: dynamic_cast -> type tag enum
+// ============================================================================
+
+void benchmark_type_checking() {
+  perf::section("Type Checking (dynamic_cast)");
+
+  const size_t ITERS = 1000000;
+
+  // Create test values
+  Value int_val(42);
+  Value str_val("hello world");
+  Value dbl_val(3.14159);
+
+  // is_int() on int value
+  PERF_BENCHMARK("perf_type_check_int_true", ITERS, {
+    bool result = int_val.is_int();
+    perf::do_not_optimize(result);
+  });
+
+  // is_int() on string value (false case)
+  PERF_BENCHMARK("perf_type_check_int_false", ITERS, {
+    bool result = str_val.is_int();
+    perf::do_not_optimize(result);
+  });
+
+  // is_string() on string value
+  PERF_BENCHMARK("perf_type_check_string_true", ITERS, {
+    bool result = str_val.is_string();
+    perf::do_not_optimize(result);
+  });
+
+  // Mixed type checking pattern (common in value dispatch)
+  PERF_BENCHMARK("perf_type_check_mixed", ITERS / 10, {
+    // Check all types on each value
+    perf::do_not_optimize(int_val.is_nil());
+    perf::do_not_optimize(int_val.is_int());
+    perf::do_not_optimize(int_val.is_int64());
+    perf::do_not_optimize(int_val.is_bool());
+    perf::do_not_optimize(int_val.is_double());
+    perf::do_not_optimize(int_val.is_string());
+    perf::do_not_optimize(int_val.is_binary());
+    perf::do_not_optimize(int_val.is_datetime());
+    perf::do_not_optimize(int_val.is_array());
+    perf::do_not_optimize(int_val.is_struct());
+  });
+}
+
+// ============================================================================
+// C. HTTP Date Formatting Benchmark (Medium Priority)
+// Target: Cache locale/facet in current_date()
+// ============================================================================
+
+void benchmark_http_date() {
+  perf::section("HTTP Date Formatting");
+
+  const size_t ITERS = 10000;
+
+  // Response_header construction calls current_date() internally
+  PERF_BENCHMARK("perf_http_response_header", ITERS, {
+    http::Response_header hdr(200, "OK");
+    perf::do_not_optimize(hdr.code());
+  });
+
+  // Also benchmark header dump (includes date in output)
+  PERF_BENCHMARK("perf_http_response_dump", ITERS, {
+    http::Response_header hdr(200, "OK");
+    hdr.set_content_length(100);
+    std::string s = hdr.dump();
+    perf::do_not_optimize(s);
+  });
+}
+
+// ============================================================================
+// D. DateTime Parsing Benchmark (Medium Priority)
+// Target: substr() allocations -> direct parsing
+// ============================================================================
+
+void benchmark_datetime_parsing() {
+  perf::section("DateTime Parsing");
+
+  const size_t ITERS = 100000;
+
+  // Parse ISO8601 datetime string
+  PERF_BENCHMARK("perf_datetime_parse", ITERS, {
+    Date_time dt("20260109T12:30:45");
+    perf::do_not_optimize(dt);
+  });
+
+  // Also benchmark serialization (to_string)
+  Date_time dt("20260109T12:30:45");
+  PERF_BENCHMARK("perf_datetime_to_string", ITERS, {
+    const std::string& s = dt.to_string();
+    perf::do_not_optimize(s);
+  });
+}
+
+// ============================================================================
+// E. Value Operations Benchmarks (Medium Priority)
+// Target: Move semantics, smart pointer optimization
+// ============================================================================
+
+void benchmark_value_operations() {
+  perf::section("Value Operations");
+
+  const size_t ITERS_SIMPLE = 100000;
+  const size_t ITERS_COMPLEX = 1000;
+
+  // Simple value clone (int)
+  Value int_val(42);
+  PERF_BENCHMARK("perf_value_clone_int", ITERS_SIMPLE, {
+    Value copy(int_val);
+    perf::do_not_optimize(copy);
+  });
+
+  // Simple value clone (string)
+  Value str_val("hello world, this is a test string");
+  PERF_BENCHMARK("perf_value_clone_string", ITERS_SIMPLE, {
+    Value copy(str_val);
+    perf::do_not_optimize(copy);
+  });
+
+  // Array clone - 10 elements
+  {
+    Array arr10;
+    for (int i = 0; i < 10; i++) arr10.push_back(i);
+    Value arr_val(arr10);
+    PERF_BENCHMARK("perf_value_clone_array_10", ITERS_SIMPLE / 10, {
+      Value copy(arr_val);
+      perf::do_not_optimize(copy);
+    });
+  }
+
+  // Array clone - 100 elements
+  {
+    Array arr100;
+    for (int i = 0; i < 100; i++) arr100.push_back(i);
+    Value arr_val(arr100);
+    PERF_BENCHMARK("perf_value_clone_array_100", ITERS_COMPLEX, {
+      Value copy(arr_val);
+      perf::do_not_optimize(copy);
+    });
+  }
+
+  // Array clone - 1000 elements
+  {
+    Array arr1000;
+    for (int i = 0; i < 1000; i++) arr1000.push_back(i);
+    Value arr_val(arr1000);
+    PERF_BENCHMARK("perf_value_clone_array_1000", ITERS_COMPLEX / 10, {
+      Value copy(arr_val);
+      perf::do_not_optimize(copy);
+    });
+  }
+
+  // Struct clone - 5 fields
+  {
+    Struct s5;
+    s5.insert("f1", "value1");
+    s5.insert("f2", "value2");
+    s5.insert("f3", 123);
+    s5.insert("f4", 3.14);
+    s5.insert("f5", true);
+    Value struct_val(s5);
+    PERF_BENCHMARK("perf_value_clone_struct_5", ITERS_SIMPLE / 10, {
+      Value copy(struct_val);
+      perf::do_not_optimize(copy);
+    });
+  }
+
+  // Struct clone - 20 fields
+  {
+    Struct s20;
+    for (int i = 0; i < 20; i++) {
+      s20.insert("field_" + std::to_string(i), i);
+    }
+    Value struct_val(s20);
+    PERF_BENCHMARK("perf_value_clone_struct_20", ITERS_COMPLEX, {
+      Value copy(struct_val);
+      perf::do_not_optimize(copy);
+    });
+  }
+
+  // Array push_back performance
+  PERF_BENCHMARK("perf_array_push_back", ITERS_COMPLEX, {
+    Array arr;
+    for (int i = 0; i < 100; i++) {
+      arr.push_back(i);
+    }
+    perf::do_not_optimize(arr);
+  });
+
+  // Struct insert performance
+  PERF_BENCHMARK("perf_struct_insert", ITERS_COMPLEX, {
+    Struct s;
+    for (int i = 0; i < 20; i++) {
+      s.insert("field_" + std::to_string(i), i);
+    }
+    perf::do_not_optimize(s);
+  });
+}
+
+// ============================================================================
+// F. Base64 Encoding/Decoding Benchmarks (Low Priority)
+// ============================================================================
+
+void benchmark_base64() {
+  perf::section("Base64 Encoding/Decoding");
+
+  const size_t ITERS_SMALL = 10000;
+  const size_t ITERS_LARGE = 1000;
+
+  // 1KB data
+  std::string data_1kb(1024, 'X');
+  std::unique_ptr<Binary_data> bin_1kb(Binary_data::from_data(data_1kb));
+
+  PERF_BENCHMARK("perf_base64_encode_1kb", ITERS_SMALL, {
+    const std::string& encoded = bin_1kb->get_base64();
+    perf::do_not_optimize(encoded);
+  });
+
+  std::string encoded_1kb = bin_1kb->get_base64();
+  PERF_BENCHMARK("perf_base64_decode_1kb", ITERS_SMALL, {
+    std::unique_ptr<Binary_data> decoded(Binary_data::from_base64(encoded_1kb));
+    const std::string& data = decoded->get_data();
+    perf::do_not_optimize(data);
+  });
+
+  // 64KB data
+  std::string data_64kb(65536, 'Y');
+  std::unique_ptr<Binary_data> bin_64kb(Binary_data::from_data(data_64kb));
+
+  PERF_BENCHMARK("perf_base64_encode_64kb", ITERS_LARGE, {
+    const std::string& encoded = bin_64kb->get_base64();
+    perf::do_not_optimize(encoded);
+  });
+
+  std::string encoded_64kb = bin_64kb->get_base64();
+  PERF_BENCHMARK("perf_base64_decode_64kb", ITERS_LARGE, {
+    std::unique_ptr<Binary_data> decoded(Binary_data::from_base64(encoded_64kb));
+    const std::string& data = decoded->get_data();
+    perf::do_not_optimize(data);
+  });
+}
+
+// ============================================================================
+// G. Full Parse/Dump Benchmarks (Integration)
+// ============================================================================
+
+// Helper to create XML response string
+std::string create_response_xml(int num_values) {
+  std::string xml = "<?xml version=\"1.0\"?>\n"
+                    "<methodResponse><params><param><value><array><data>\n";
+  for (int i = 0; i < num_values; i++) {
+    xml += "<value><struct>"
+           "<member><name>id</name><value><i4>" + std::to_string(i) + "</i4></value></member>"
+           "<member><name>name</name><value><string>item" + std::to_string(i) + "</string></value></member>"
+           "<member><name>price</name><value><double>" + std::to_string(i * 1.5) + "</double></value></member>"
+           "</struct></value>\n";
+  }
+  xml += "</data></array></value></param></params></methodResponse>";
+  return xml;
+}
+
+void benchmark_parse_dump() {
+  perf::section("Full Parse/Dump (Integration)");
+
+  const size_t ITERS = 100;
+
+  // Small response (10 structs)
+  std::string xml_small = create_response_xml(10);
+  PERF_BENCHMARK("perf_parse_response_10", ITERS * 10, {
+    Parser p(xml_small);
+    ResponseBuilder b(p);
+    b.build();
+    Response r = b.get();
+    perf::do_not_optimize(r);
+  });
+
+  // Large response (1000 structs)
+  std::string xml_large = create_response_xml(1000);
+  PERF_BENCHMARK("perf_parse_response_1000", ITERS, {
+    Parser p(xml_large);
+    ResponseBuilder b(p);
+    b.build();
+    Response r = b.get();
+    perf::do_not_optimize(r);
+  });
+
+  // Dump small response
+  {
+    Array arr;
+    for (int i = 0; i < 10; i++) {
+      Struct s;
+      s.insert("id", i);
+      s.insert("name", "item" + std::to_string(i));
+      s.insert("price", i * 1.5);
+      arr.push_back(s);
+    }
+    Value* v = new Value(arr);
+    Response resp(v);
+
+    PERF_BENCHMARK("perf_dump_response_10", ITERS * 10, {
+      std::string xml = dump_response(resp);
+      perf::do_not_optimize(xml);
+    });
+  }
+
+  // Dump large response
+  {
+    Array arr;
+    for (int i = 0; i < 1000; i++) {
+      Struct s;
+      s.insert("id", i);
+      s.insert("name", "item" + std::to_string(i));
+      s.insert("price", i * 1.5);
+      arr.push_back(s);
+    }
+    Value* v = new Value(arr);
+    Response resp(v);
+
+    PERF_BENCHMARK("perf_dump_response_1000", ITERS, {
+      std::string xml = dump_response(resp);
+      perf::do_not_optimize(xml);
+    });
+  }
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+int main(int argc, char* argv[]) {
+  std::cout << "============================================================\n";
+  std::cout << "libiqxmlrpc2 Performance Benchmark\n";
+
+  // Get current time
+  std::time_t now = std::time(nullptr);
+  char time_buf[64];
+  std::strftime(time_buf, sizeof(time_buf), "%Y-%m-%d %H:%M:%S", std::localtime(&now));
+  std::cout << "Date: " << time_buf << "\n";
+  std::cout << "============================================================\n";
+
+  perf::ResultCollector::instance().start_suite();
+
+  // Run all benchmarks
+  benchmark_number_conversions();
+  benchmark_type_checking();
+  benchmark_http_date();
+  benchmark_datetime_parsing();
+  benchmark_value_operations();
+  benchmark_base64();
+  benchmark_parse_dump();
+
+  // Save baseline
+  std::strftime(time_buf, sizeof(time_buf), "%Y%m%d_%H%M%S", std::localtime(&now));
+  std::string baseline_file = "performance_baseline.txt";
+  perf::ResultCollector::instance().save_baseline(baseline_file);
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

- Add comprehensive performance test suite to establish baseline metrics before implementing optimizations
- Benchmarks run separately from unit tests via `make perf-test`

### Benchmarks included (31 total):

| Category | Tests | Purpose |
|----------|-------|---------|
| Number Conversion | 6 | Measure `boost::lexical_cast` overhead |
| Type Checking | 4 | Measure `dynamic_cast` overhead |
| HTTP Date | 2 | Measure locale/facet creation cost |
| DateTime Parsing | 2 | Measure `substr()` allocation overhead |
| Value Operations | 9 | Measure clone and insertion costs |
| Base64 | 4 | Measure encoding/decoding performance |
| Parse/Dump | 4 | End-to-end integration benchmarks |

### Usage

```bash
cd build
cmake ..
make -j4
make perf-test   # Run benchmarks
```

Results are saved to `tests/performance_baseline.txt` for comparison after optimizations.

## Test plan

- [x] Build passes: `make -j4 performance-test`
- [x] Benchmarks run successfully: `make perf-test`
- [x] Results saved to baseline file
- [x] Existing unit tests unaffected: `make check`