### PR TITLE
Exclude all test files from Codecov coverage report

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,11 +1,5 @@
 ignore:
-  - "tests/test_server.cc"
-  - "tests/client.cc"
-  - "tests/client_stress.cc"
-  - "tests/server_config.cc"
-  - "tests/client_common.cc"
-  - "tests/client_opts.cc"
-  - "tests/test_integration.cc"
+  - "tests/**/*"  # Exclude all test files from coverage report
 
 coverage:
   status:


### PR DESCRIPTION
## Summary
- Use glob pattern `tests/**/*` to exclude all test files from coverage metrics
- Replaces the previous approach of listing individual test files

## Why
Test files themselves don't need coverage tracking - they *are* the tests. Including them in the coverage report:
1. Inflates the "missing coverage" count artificially
2. Makes it harder to identify actual library code that needs coverage
3. Requires manual updates whenever new test files are added

## Test Plan
- [x] Verify codecov.yml syntax is valid
- [ ] Check that Codecov report excludes test files after merge