### PR TITLE
Fix cppcheck errors and style issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,4 +146,5 @@ jobs:
         cppcheck --enable=warning,style,performance \
           --suppress=missingIncludeSystem \
           --inline-suppr \
+          --error-exitcode=1 \
           libiqxmlrpc/

--- a/libiqxmlrpc/inet_addr.cc
+++ b/libiqxmlrpc/inet_addr.cc
@@ -42,7 +42,7 @@ std::string get_host_name()
 #if defined(__sun) || defined(sun)
 #define IQXMLRPC_GETHOSTBYNAME(_h) \
   IQXMLRPC_GETHOSTBYNAME_PREP \
-  hent = ::gethostbyname_r( _h), &hent_local, buf, sizeof(buf), &local_h_errno ); \
+  hent = ::gethostbyname_r( _h, &hent_local, buf, sizeof(buf), &local_h_errno ); \
   IQXMLRPC_GETHOSTBYNAME_POST
 #endif
 

--- a/libiqxmlrpc/method.h
+++ b/libiqxmlrpc/method.h
@@ -107,6 +107,7 @@ public:
 
   virtual ~Interceptor() {}
 
+  // cppcheck-suppress constParameterPointer
   void nest(Interceptor* ic)
   {
     nested.reset(ic);

--- a/libiqxmlrpc/reactor_poll_impl.cc
+++ b/libiqxmlrpc/reactor_poll_impl.cc
@@ -35,8 +35,8 @@ void Reactor_poll_impl::reset(const HandlerStateList& in)
 
   for (const auto& h : in)
   {
-    short events = h.mask & Reactor_base::INPUT ? POLLIN : 0;
-    events |= h.mask & Reactor_base::OUTPUT ? POLLOUT : 0;
+    short events = (h.mask & Reactor_base::INPUT) ? POLLIN : 0;
+    events |= (h.mask & Reactor_base::OUTPUT) ? POLLOUT : 0;
     struct pollfd sfd = { h.fd, events, 0 };
     impl->pfd.push_back(sfd);
   }

--- a/libiqxmlrpc/reactor_select_impl.cc
+++ b/libiqxmlrpc/reactor_select_impl.cc
@@ -10,7 +10,8 @@ using namespace iqnet;
 
 typedef Reactor_base::HandlerStateList HandlerStateList;
 
-Reactor_select_impl::Reactor_select_impl()
+Reactor_select_impl::Reactor_select_impl():
+  max_fd(0)
 {
 }
 

--- a/libiqxmlrpc/value.cc
+++ b/libiqxmlrpc/value.cc
@@ -151,12 +151,6 @@ T* Value::cast() const
   return t;
 }
 
-template <class T>
-bool Value::can_cast() const
-{
-  return dynamic_cast<T*>( value ) != nullptr;
-}
-
 const Value& Value::operator =( const Value& v )
 {
   Value_type* tmp = v.value->clone();

--- a/libiqxmlrpc/value.h
+++ b/libiqxmlrpc/value.h
@@ -145,7 +145,6 @@ public:
 
 private:
   template <class T> T* cast() const;
-  template <class T> bool can_cast() const;
 };
 
 class XmlBuilder;


### PR DESCRIPTION
## Summary
- Fix syntax error in Solaris `gethostbyname_r` macro (typo: `_h),` → `_h,`)
- Initialize `max_fd` member in `Reactor_select_impl` constructor to fix uninitMemberVar warning
- Add parentheses to clarify `&` vs `?:` precedence in `reactor_poll_impl.cc`
- Remove unused `can_cast<T>()` private template function from `Value` class
- Add `cppcheck-suppress` for false positive `constParameterPointer` warnings where ownership is transferred
- Enable `--error-exitcode=1` in CI workflow to fail builds on cppcheck errors

## Test plan
- [x] Verified cppcheck passes locally with no errors/warnings
- [ ] CI cppcheck job passes
- [ ] All other CI checks pass (build, tests, ASan/UBSan, coverage)