### PR TITLE
Optimize Base64 decoding with lookup table

### DIFF
--- a/libiqxmlrpc/value_type.h
+++ b/libiqxmlrpc/value_type.h
@@ -310,6 +310,7 @@ public:
 
 private:
   static const char base64_alpha[64];
+  static const signed char base64_decode[256];
 
   std::string data;
   mutable std::string base64;
@@ -332,15 +333,10 @@ public:
   void apply_visitor( Value_type_visitor& ) const override;
 
 private:
-  class End_of_data {};
-
   Binary_data( const std::string&, bool raw );
 
   void add_base64_char( int idx ) const;
   void encode() const;
-
-  static char get_idx( char );
-  void decode_four( const char* four );
   void decode();
 };
 


### PR DESCRIPTION
## Summary
- Replace linear search through 64-character base64 alphabet with 256-byte lookup table for O(1) character-to-value conversion
- Replace exception-based padding detection (`End_of_data`) with direct if-statement checks
- Use `reserve()` + `push_back()` instead of `resize()` to avoid zero-initialization overhead

## Performance Results

| Benchmark | Before (ns/op) | After (ns/op) | Improvement |
|-----------|----------------|---------------|-------------|
| decode_1kb | 25,073 | 5,361 | **4.7x faster** |
| decode_64kb | 1,339,331 | 328,213 | **4.1x faster** |

## Test plan
- [x] All existing tests pass (`make check`)
- [x] Base64 encode/decode roundtrip verified
- [x] Malformed input still throws `Malformed_base64` exception