### PR TITLE
Enable TCP_NODELAY by default to reduce RPC latency

### DIFF
--- a/libiqxmlrpc/socket.h
+++ b/libiqxmlrpc/socket.h
@@ -38,6 +38,10 @@ public:
   //! \note Does not disable non-blocking mode under UNIX.
   void set_non_blocking( bool );
 
+  //! Enable/disable TCP_NODELAY (Nagle's algorithm).
+  //! Recommended for RPC workloads to reduce latency.
+  void set_nodelay( bool enable );
+
   /*! \b Can \b not cause SIGPIPE signal. */
   virtual size_t send( const char*, size_t );
   virtual void send_shutdown( const char*, size_t );


### PR DESCRIPTION
## Summary
- Add `set_nodelay(bool)` method to Socket class
- Enable TCP_NODELAY by default on all sockets

## Why this matters

Nagle's algorithm buffers small packets, waiting up to 200ms for more data or an ACK. Combined with delayed ACK on the receiver (40ms), this creates **40-400ms latency** per RPC call.

XML-RPC messages are typically small and follow request-response patterns - exactly where Nagle hurts most. Disabling it via TCP_NODELAY eliminates this artificial delay.

## Changes
- `Socket::Socket()`: Enable TCP_NODELAY for client sockets
- `Socket::accept()`: Enable TCP_NODELAY for accepted connections
- New `set_nodelay(bool)` method for manual control if needed

## Test plan
- [x] All unit tests pass (`make check`)
- [x] Integration tests pass (in-process server/client)
- [x] Cross-platform: Uses standard IPPROTO_TCP/TCP_NODELAY