### PR TITLE
Use atomic<bool> for thread pool destructor flag

### DIFF
--- a/libiqxmlrpc/executor.h
+++ b/libiqxmlrpc/executor.h
@@ -20,6 +20,7 @@
 #pragma warning(pop)
 #endif
 
+#include <atomic>
 #include <deque>
 #include <vector>
 
@@ -144,8 +145,7 @@ class LIBIQXMLRPC_API Pool_executor_factory: public Executor_factory_base {
   boost::mutex               req_queue_lock;
   boost::condition           req_queue_cond;
 
-  bool          in_destructor;
-  boost::mutex  destructor_lock;
+  std::atomic<bool> in_destructor;
 
 public:
   explicit Pool_executor_factory(unsigned num_threads);


### PR DESCRIPTION
## Summary
Replace mutex-protected bool with `std::atomic<bool>` for the `in_destructor` flag in `Pool_executor_factory`.

## Rationale
The current implementation uses a mutex to protect a single bool that's:
- Written once (during destruction)
- Read occasionally (by pool threads checking if shutdown is in progress)

`std::atomic<bool>` is the appropriate primitive for this pattern:
- **Code clarity**: Better expresses the intent (flag set once, read many)
- **Minor efficiency**: Removes mutex overhead (~50-200 cycles → ~1-5 cycles per check)
- **Proper semantics**: Uses release/acquire memory ordering for synchronization

## Changes
- `executor.h`: Replace `bool in_destructor` + `boost::mutex destructor_lock` with `std::atomic<bool> in_destructor`
- `executor.cc`: Use `store()`/`load()` with proper memory ordering

## Test plan
- [x] All unit tests pass (`make check`)
- [x] Integration tests pass (thread pool shutdown tested)