### PR TITLE
Add tests for acceptor.cc, http_server.cc, and method.cc coverage

### DIFF
--- a/tests/methods.cc
+++ b/tests/methods.cc
@@ -11,6 +11,7 @@ using namespace iqxmlrpc;
 void register_user_methods(iqxmlrpc::Server& s)
 {
   register_method<serverctl_stop>(s, "serverctl.stop");
+  register_method<serverctl_log>(s, "serverctl.log");
   register_method(s, "echo", echo_method);
   register_method(s, "echo_user", echo_user);
   register_method(s, "error_method", error_method);
@@ -20,12 +21,24 @@ void register_user_methods(iqxmlrpc::Server& s)
   register_method<Get_file>(s, "get_file");
 }
 
-void serverctl_stop::execute( 
+void serverctl_stop::execute(
   const iqxmlrpc::Param_list&, iqxmlrpc::Value& )
 {
   BOOST_TEST_MESSAGE("Stop_server method invoked.");
   server().log_message( "Stopping the server." );
   server().set_exit_flag();
+}
+
+void serverctl_log::execute(
+  const iqxmlrpc::Param_list& args, iqxmlrpc::Value& result )
+{
+  BOOST_TEST_MESSAGE("Log_message method invoked.");
+  std::string msg = "Test log message";
+  if (!args.empty() && args[0].is_string()) {
+    msg = args[0].get_string();
+  }
+  server().log_message(msg);
+  result = true;
 }
 
 

--- a/tests/methods.h
+++ b/tests/methods.h
@@ -11,6 +11,11 @@ public:
   void execute( const iqxmlrpc::Param_list&, iqxmlrpc::Value& );
 };
 
+class serverctl_log: public iqxmlrpc::Method {
+public:
+  void execute( const iqxmlrpc::Param_list&, iqxmlrpc::Value& );
+};
+
 void echo_method(iqxmlrpc::Method*, const iqxmlrpc::Param_list&, iqxmlrpc::Value&);
 void echo_user(iqxmlrpc::Method*, const iqxmlrpc::Param_list&, iqxmlrpc::Value&);
 void trace_method(iqxmlrpc::Method*, const iqxmlrpc::Param_list&, iqxmlrpc::Value&);


### PR DESCRIPTION
## Summary

Add tests to improve code coverage for three areas:

- **acceptor.cc firewall rejection (lines 57-68):** Tests for both empty message (socket shutdown only) and custom message paths. Note: Firewall must be set BEFORE starting server because the firewall is propagated to the acceptor once at the start of `work()`.

- **http_server.cc error handling (lines 100-104, 136-147):** Tests for invalid HTTP method responses and exception logging paths.

- **method.cc normal paths (lines 19, 27):** Added `serverctl.log` method to test `log_message()` without stopping server. Also test `set_exit_flag()` via `serverctl.stop` with proper shutdown handling.

## Test plan

- [x] All coverage_improvement_tests pass locally (16 tests)
- [x] Full test suite passes (`make check` - 11 test executables)
- [x] CI builds pass on all platforms
- [x] Coverage metrics verified via Codecov