### PR TITLE
Add interoperability tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - name: ubi8
             runner: ubuntu-latest
             container: redhat/ubi8
-            install: dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && dnf install -y gcc-c++ cmake make boost169-devel libxml2-devel openssl-devel && ln -s /usr/include/boost169/boost /usr/include/boost && ln -s /usr/lib64/boost169/* /usr/lib64/
+            install: dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && dnf install -y gcc-c++ cmake make boost169-devel libxml2-devel openssl-devel python3 && ln -s /usr/include/boost169/boost /usr/include/boost && ln -s /usr/lib64/boost169/* /usr/lib64/
           - name: macos
             runner: macos-latest
             container: ""


### PR DESCRIPTION
## Summary

Run wire protocol interoperability tests in CI after unit tests complete.

## Changes

- Add "Interop Test" step to the build job that runs `make interop-test`
- Tests run on all platforms (ubuntu-24.04, ubi8, macos)

## What it tests

The interop tests verify that libiqxmlrpc can communicate correctly with Python's standard `xmlrpc.server`:
- All XML-RPC value types (int, double, bool, string, struct, array)
- Edge cases (empty values, UTF-8, XML special characters, INT_MIN/MAX)
- Fault handling
- Arithmetic operations

## Test plan

- [ ] CI passes on all platforms
- [ ] Interop tests run successfully in CI logs