### PR TITLE
P3: Replace exceptions with return codes in SSL hot path

### DIFF
--- a/libiqxmlrpc/ssl_connection.h
+++ b/libiqxmlrpc/ssl_connection.h
@@ -44,6 +44,33 @@ protected:
 
   bool shutdown_recved();
   bool shutdown_sent();
+
+  //! Non-throwing SSL read (P3 optimization).
+  /*! Returns result code instead of throwing for WANT_READ/WANT_WRITE.
+      \param buf Buffer to read into
+      \param len Max bytes to read
+      \param bytes_read Output: actual bytes read (only valid if OK returned)
+      \return SslIoResult indicating success or what to wait for
+  */
+  SslIoResult try_ssl_read( char* buf, size_t len, size_t& bytes_read );
+
+  //! Non-throwing SSL write (P3 optimization).
+  /*! Returns result code instead of throwing for WANT_READ/WANT_WRITE.
+      \param buf Buffer to write from
+      \param len Bytes to write
+      \param bytes_written Output: actual bytes written (only valid if OK returned)
+      \return SslIoResult indicating success or what to wait for
+  */
+  SslIoResult try_ssl_write( const char* buf, size_t len, size_t& bytes_written );
+
+  //! Non-throwing SSL accept (P3 optimization).
+  SslIoResult try_ssl_accept_nonblock();
+
+  //! Non-throwing SSL connect (P3 optimization).
+  SslIoResult try_ssl_connect_nonblock();
+
+  //! Non-throwing SSL shutdown (P3 optimization).
+  SslIoResult try_ssl_shutdown_nonblock();
 };
 
 //! Server-side established SSL-connection based on reactive model


### PR DESCRIPTION
## Summary
Eliminates ~800x overhead of exception throwing for normal WANT_READ/WANT_WRITE cases in non-blocking SSL I/O by using return codes instead.

## Problem
The current implementation uses exceptions for normal control flow in SSL non-blocking I/O:
- `SSL_ERROR_WANT_READ` → throws `need_read()`
- `SSL_ERROR_WANT_WRITE` → throws `need_write()`

These are **expected** states in non-blocking I/O, not errors. Exception throwing costs ~3000ns per throw, while return code checking costs ~4ns.

## Solution
- Add `SslIoResult` enum: `{OK, WANT_READ, WANT_WRITE, CONNECTION_CLOSE, ERROR}`
- Add `check_io_result()` function returning `SslIoResult` instead of throwing
- Add non-throwing SSL methods for the hot path
- Refactor `Reaction_connection::switch_state()` to use return codes

## Benchmark Results

| Path | Time per op | Notes |
|------|-------------|-------|
| Return code (WANT_READ) | **4 ns** | New implementation |
| Exception (WANT_READ) | **3,000 ns** | Old implementation |
| **Speedup** | **~750x** | Per WANT_READ/WANT_WRITE event |

## Impact
Non-blocking SSL I/O typically generates 3-10 WANT_* events per read/write operation:
- Before: 3-10 × 3,000 ns = **9,000-30,000 ns** exception overhead
- After: 3-10 × 4 ns = **12-40 ns** return code overhead
- **Savings: 9,000-30,000 ns per SSL read/write operation**

## Files Changed
- `libiqxmlrpc/ssl_lib.h` - Add SslIoResult enum and check_io_result() declaration
- `libiqxmlrpc/ssl_lib.cc` - Add check_io_result() implementation
- `libiqxmlrpc/ssl_connection.h` - Add non-throwing SSL method declarations
- `libiqxmlrpc/ssl_connection.cc` - Add implementations and refactor switch_state()
- `tests/test_performance.cc` - Add exception vs return code benchmark

## Test plan
- [x] All existing tests pass
- [x] Benchmark added to measure exception vs return code overhead
- [x] Integration tests verify SSL functionality unchanged