### PR TITLE
Add development guidelines for contributors

### DIFF
--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -1,0 +1,15 @@
+# Coding Standards
+
+## Code Quality
+
+- Write clean, readable code with meaningful names
+- Prefer simple solutions over clever ones
+- Keep functions focused and under 50 lines when practical
+- Avoid over-engineering - only add complexity when needed
+
+## Documentation
+
+- Update documentation when changing behavior
+- Keep comments current with code
+- Document non-obvious design decisions
+- Avoid obvious comments that repeat the code

--- a/docs/COVERAGE_GUIDE.md
+++ b/docs/COVERAGE_GUIDE.md
@@ -1,4 +1,11 @@
-# Code Coverage Guide
+# Testing & Coverage Guide
+
+## General Testing Rules
+
+- Add tests for new functionality
+- Run existing tests before committing
+- Fix broken tests immediately
+- Prefer unit tests over integration tests when possible
 
 ## Coverage Targets
 - **Lines:** 95%

--- a/docs/PROJECT_RULES.md
+++ b/docs/PROJECT_RULES.md
@@ -15,11 +15,15 @@ make perf-test                                     # Run benchmarks
 ```
 
 ## Git Workflow
-- Commit to feature branches, not master
+
+- Create feature branches for all changes
+- Write descriptive commit messages explaining "why" not just "what"
 - Create PRs and merge after CI passes
+- Never force push to main/master
 - Check CI: `gh pr view <PR> --json statusCheckRollup`
 
 ## CI Checks
+
 PRs must pass: ubuntu-24.04, ubi8, macos builds | ASan/UBSan | coverage | cppcheck | CodeQL
 
 ## Architecture
@@ -37,24 +41,12 @@ PRs must pass: ubuntu-24.04, ubi8, macos builds | ASan/UBSan | coverage | cppche
 - `Method` — base class for RPC methods; register via `register_method()`
 - `Executor_factory_base` — threading model (Serial or Pool)
 
-## Testing
-
-- **Framework**: Boost.Test
-- **Unit tests**: `tests/test_*.cc`
-- **Coverage targets**: 95% lines, 60% branches
-- **Detailed guide**: `docs/COVERAGE_GUIDE.md`
-
-## Performance
-
-- **Benchmarks**: `make perf-test`
-- **Guidelines**: `docs/PERFORMANCE_GUIDE.md`
-
 ## Reference Docs
 
 | Topic | File |
 |-------|------|
-| Performance rules & hot paths | `docs/PERFORMANCE_GUIDE.md` |
-| Coverage patterns & pitfalls | `docs/COVERAGE_GUIDE.md` |
+| Coding standards | `docs/CODING_STANDARDS.md` |
+| Testing & coverage | `docs/COVERAGE_GUIDE.md` |
+| Performance rules | `docs/PERFORMANCE_GUIDE.md` |
 | SSL/HTTPS testing | `docs/SSL_TESTING.md` |
 | Debugging tips | `docs/DEBUGGING.md` |
-| Wire compatibility | `COMPATIBILITY_TESTING_PLAN.md` |


### PR DESCRIPTION
## Summary
Add development guidelines from global rules, organized for token efficiency.

## Changes

| File | Change |
|------|--------|
| `docs/CODING_STANDARDS.md` | **New** - Code quality and documentation rules |
| `docs/COVERAGE_GUIDE.md` | Renamed to "Testing & Coverage Guide", added general testing rules |
| `docs/PROJECT_RULES.md` | Kept lean with references to topic-specific guides |

## Token Efficiency

Rules are distributed across topic-specific files (loaded on-demand) rather than all in PROJECT_RULES.md (loaded every turn):

| Rule Type | Location |
|-----------|----------|
| Code quality | `CODING_STANDARDS.md` |
| Testing | `COVERAGE_GUIDE.md` |
| Performance | `PERFORMANCE_GUIDE.md` |
| Git/CI basics | `PROJECT_RULES.md` |

## Test plan
- [x] No sensitive information in docs/
- [x] Rules are available to all contributors via docs/