### PR TITLE
Add defensive synchronization and robustness improvements

### DIFF
--- a/libiqxmlrpc/reactor_impl.h
+++ b/libiqxmlrpc/reactor_impl.h
@@ -209,6 +209,12 @@ void Reactor<Lock>::invoke_servers_handler(
   }
 }
 
+// THREADING SAFETY NOTE:
+// This function is ONLY called from the reactor thread. Handler registration
+// and unregistration also only occur from the reactor thread. This single-threaded
+// access pattern guarantees that the handler pointer remains valid throughout
+// this function's execution, even though find_handler() releases the lock.
+// If this threading model changes, consider using shared_ptr for handlers.
 template <class Lock>
 void Reactor<Lock>::invoke_event_handler( const Reactor_base::HandlerState& hs )
 {

--- a/libiqxmlrpc/server.cc
+++ b/libiqxmlrpc/server.cc
@@ -43,6 +43,10 @@ public:
   const Auth_Plugin_base*    auth_plugin;
 
   std::atomic<int64_t> idle_timeout_ms{0};
+
+  // Mutex for connections set - provides defensive synchronization.
+  // Currently all access is from the reactor thread, but mutex protects
+  // against future changes or API misuse.
   std::set<Server_connection*> connections;
   mutable std::mutex connections_mutex;
 

--- a/libiqxmlrpc/socket.cc
+++ b/libiqxmlrpc/socket.cc
@@ -22,15 +22,21 @@ Socket::Socket():
 
 #ifndef WIN32
   {
+  // SO_REUSEADDR allows immediate reuse of the port after server restart.
+  // Return value intentionally ignored - this is a "best effort" optimization
+  // that should not prevent socket creation if it fails.
   int enable = 1;
-  setsockopt( sock, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable) );
+  (void)setsockopt( sock, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable) );
   }
 #endif //WIN32
 
 #if defined(__APPLE__)
   {
+  // SO_NOSIGPIPE prevents SIGPIPE on write to closed socket (macOS-specific).
+  // Return value intentionally ignored - fallback is to catch SIGPIPE or
+  // handle EPIPE error on send().
   int enable = 1;
-  setsockopt( sock, SOL_SOCKET, SO_NOSIGPIPE, &enable, sizeof(enable) );
+  (void)setsockopt( sock, SOL_SOCKET, SO_NOSIGPIPE, &enable, sizeof(enable) );
   }
 #endif
 
@@ -76,9 +82,12 @@ void Socket::set_non_blocking( bool flag )
 
 void Socket::set_nodelay( bool enable )
 {
+  // TCP_NODELAY disables Nagle's algorithm for lower latency.
+  // Return value intentionally ignored - this is a performance optimization
+  // that should not prevent communication if it fails.
   int flag = enable ? 1 : 0;
-  setsockopt( sock, IPPROTO_TCP, TCP_NODELAY,
-              reinterpret_cast<const char*>(&flag), sizeof(flag) );
+  (void)setsockopt( sock, IPPROTO_TCP, TCP_NODELAY,
+                    reinterpret_cast<const char*>(&flag), sizeof(flag) );
 }
 
 #if defined(MSG_NOSIGNAL)


### PR DESCRIPTION
## Summary

Addresses remaining items from the bug report (`docs/BUG_REPORT.md`) with defensive synchronization and robustness improvements.

## Changes

### 1. SSL Partial Write Handling (`ssl_connection.cc`)
- Add retry loop for partial writes in blocking `send()`
- Handles edge cases when `SSL_MODE_ENABLE_PARTIAL_WRITE` is enabled

### 2. Handler Threading Safety (`reactor_impl.h`)  
- Add documentation explaining single-threaded access guarantee
- Handler lifetime is safe because all access is from reactor thread

### 3. Server Connection Set Mutex (`server.cc`)
- Add `connections_mutex` to protect connections set
- Defensive design against future threading model changes

### 4. Idle State Mutex (`server_conn.cc/h`)
- Add `idle_mutex_` to protect idle state fields
- Protects `is_waiting_input_` and `idle_since_`

### 5. setsockopt Documentation (`socket.cc`)
- Add comments explaining intentional return value ignore
- Use `(void)` cast to suppress compiler warnings

## Test Plan

New `defensive_sync_tests` suite with 4 test cases:

- [x] `concurrent_connection_registration` - 20 concurrent clients
- [x] `large_data_transfer` - 64KB data (exercises SSL partial writes)
- [x] `rapid_connection_cycling` - 10 cycles × 5 concurrent connections
- [x] `idle_state_transitions` - 5 keep-alive requests

All existing tests continue to pass (`make check`).

## Files Modified

| File | Changes |
|------|---------|
| `ssl_connection.cc` | Add partial write retry loop |
| `reactor_impl.h` | Add threading safety comment |
| `server.cc` | Add `connections_mutex` |
| `server_conn.h` | Add `idle_mutex_` |
| `server_conn.cc` | Use mutex in idle state methods |
| `socket.cc` | Add documentation, `(void)` casts |
| `test_integration.cc` | Add `defensive_sync_tests` suite |