### PR TITLE
Add missing header guard to value_type_xml.h

### DIFF
--- a/libiqxmlrpc/value_type_xml.h
+++ b/libiqxmlrpc/value_type_xml.h
@@ -1,6 +1,9 @@
 //  Libiqxmlrpc - an object-oriented XML-RPC solution.
 //  Copyright (C) 2011 Anton Dedov
 
+#ifndef _iqxmlrpc_value_type_xml_h_
+#define _iqxmlrpc_value_type_xml_h_
+
 #include <string>
 #include "value_type_visitor.h"
 
@@ -35,3 +38,5 @@ private:
 };
 
 } // namespace iqxmlrpc
+
+#endif // _iqxmlrpc_value_type_xml_h_


### PR DESCRIPTION
## Summary

Fix CodeQL alert #10 (`cpp/missing-header-guard`). The header file `value_type_xml.h` was missing include guards.

## Changes

- Added `#ifndef _iqxmlrpc_value_type_xml_h_` / `#define` / `#endif` header guard

## CodeQL Alert Analysis

Reviewed all 12 open CodeQL alerts. **11 are false positives**, only this one (missing header guard) required fixing:

| Alert | Status | Reason |
|-------|--------|--------|
| #10 Missing header guard | **FIXED** | Header guard added |
| #17 Stack address escape | False positive | Only POD values stored, no local addresses |
| #3,4,5,6,18,19,20 Unused variables | False positive | RAII lock guards (used via destructor) |
| #11 Continue doesn't continue | False positive | Valid EINTR retry pattern in do-while |
| #8 Complex condition | False positive | Appropriate datetime validation |
| #12,13 Commented-out code | False positive | Documentation/future features |

## Test plan

- [x] Build passes
- [x] All 12 tests pass (`make check`)
- [ ] CodeQL re-scans and marks alert #10 as fixed