### PR TITLE
Potential fix for code scanning alert no. 20: Unused local variable

### DIFF
--- a/libiqxmlrpc/reactor_impl.h
+++ b/libiqxmlrpc/reactor_impl.h
@@ -133,7 +133,7 @@ void Reactor<Lock>::register_handler( Event_handler* eh, Event_mask mask )
 template <class Lock>
 void Reactor<Lock>::unregister_handler( Event_handler* eh, Event_mask mask )
 {
-  scoped_lock lk(lock);
+  [[maybe_unused]] scoped_lock lk(lock);
   hs_iterator i = find_handler_state( eh );
 
   if( i != end() )


### PR DESCRIPTION
Potential fix for [https://github.com/yarikmsu/libiqxmlrpc/security/code-scanning/20](https://github.com/yarikmsu/libiqxmlrpc/security/code-scanning/20)

In general, when a local variable is intentionally unused but needed for its lifetime side effects (like RAII locks), you should keep it but explicitly mark it as intentionally unused to satisfy static analysis and avoid confusion. Removing such a variable would change behavior; changing it to a temporary expression without a name might also change name-based suppression logic.

The best way to fix this without changing functionality is to keep the `scoped_lock` construction but add an attribute that marks the variable as “maybe unused” while preserving its lifetime. In modern C++, this can be done with the standard `[[maybe_unused]]` attribute. That way, `lk` is still constructed at the beginning of the function (locking the mutex) and destroyed at the end (unlocking), but CodeQL and compilers that understand attributes will no longer warn about it being unused.

Concretely, in `libiqxmlrpc/reactor_impl.h`, in the `Reactor<Lock>::unregister_handler` template definition, change line 136 from:

```cpp
  scoped_lock lk(lock);
```

to:

```cpp
  [[maybe_unused]] scoped_lock lk(lock);
```

No extra headers are required for `[[maybe_unused]]` (it is a language feature), and no other code changes are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
