### PR TITLE
Add CPP_STYLE.md and consolidate documentation references

### DIFF
--- a/docs/CPP_STYLE.md
+++ b/docs/CPP_STYLE.md
@@ -1,0 +1,58 @@
+# C++ Style Guidelines
+
+Project-specific C++ patterns for libiqxmlrpc development.
+
+## Performance-Critical Patterns
+
+**Avoid in hot paths:**
+
+| Anti-Pattern | Alternative | Why |
+|--------------|-------------|-----|
+| `boost::lexical_cast` | `num_conv::to_string/from_string` | 8-12x faster |
+| `dynamic_cast` for type checks | `value->type_tag()` | 10x faster |
+| `std::locale` construction | `strftime` directly | 3-4x faster |
+| `substr()` for parsing | `std::string_view` | Avoids allocation |
+
+**Prefer:**
+- `std::to_string()` for integers (highly optimized in modern libc++)
+- `std::from_chars()` for parsing (no locale overhead)
+- `ValueTypeTag` enum comparison for type checks
+- Stack buffers with `snprintf`/`strftime` for formatting
+
+## Code Patterns
+
+### Value System
+- `Value` - proxy class for all XML-RPC types
+- `ValueTypeTag` - enum for O(1) type identification
+- Use `value->type_tag()` instead of `dynamic_cast`
+
+### Number Conversion
+- `num_conv::to_string<T>()` - fast integer-to-string
+- `num_conv::from_string<T>()` - fast string-to-integer
+- `num_conv::double_to_string()` - IEEE 754 precision (17 digits)
+
+## Thread Safety Patterns
+
+### Simple flags/pointers shared across threads
+- Use `std::atomic<bool>` for flags (e.g., `exit_flag`)
+- Use `std::atomic<T*>` for pointers set from one thread, read from another
+
+### Lazy initialization
+- Use `std::call_once` with `std::once_flag` for thread-safe one-time init
+- Initialize `once_flag` in constructor initializer list (`-Weffc++` requirement)
+
+### Collections
+- Protect with `std::mutex` and `std::lock_guard`
+- Minimize lock scope - copy data out, release lock, then process
+
+### DNS lookups
+- Use `dns_mutex()` in `inet_addr.cc` - glibc's resolver has internal shared state
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `libiqxmlrpc/num_conv.h` | Fast number conversions |
+| `libiqxmlrpc/value.h` | Value proxy class |
+| `libiqxmlrpc/value_type.h` | ValueTypeTag enum |
+| `libiqxmlrpc/safe_math.h` | Overflow-safe arithmetic |

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -1,24 +1,21 @@
 # Debugging Guide
 
-## Running Tests
-
-### Single Test with Verbose Output
-```bash
-./tests/integration-test --run_test=network_error_tests/client_connection_timeout --log_level=all
-```
-
-### Run Specific Test Suite
-```bash
-./tests/integration-test --run_test=network_error_tests
-```
+Quick reference for debugging. For detailed guides, see related docs.
 
 ## Memory Debugging
 
-### AddressSanitizer (Local)
+### AddressSanitizer (ASan/UBSan)
 ```bash
-cmake .. -DCMAKE_CXX_FLAGS="-fsanitize=address -fno-omit-frame-pointer"
-make integration-test
-./tests/integration-test
+cmake .. -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer"
+make check
+```
+
+### ThreadSanitizer (TSan)
+```bash
+cmake .. -DCMAKE_CXX_COMPILER=clang++ \
+  -DCMAKE_CXX_FLAGS="-fsanitize=thread -fno-omit-frame-pointer -g" \
+  -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread"
+make check
 ```
 
 ### Valgrind
@@ -26,45 +23,24 @@ make integration-test
 valgrind --leak-check=full ./tests/integration-test
 ```
 
-## Coverage Debugging
+## Performance Profiling
 
-### Find Uncovered Lines
-```bash
-gcov -b libiqxmlrpc/CMakeFiles/iqxmlrpc.dir/connector.cc.gcno
-grep -n "#####" connector.cc.gcov
-```
+See `@docs/PERFORMANCE_GUIDE.md` for benchmark workflows.
 
-## Performance Debugging
-
-### Compare Before/After Changes
-```bash
-make perf-test
-cp tests/performance_baseline.txt tests/baseline_before.txt
-# ... make changes ...
-make perf-test
-diff tests/baseline_before.txt tests/performance_baseline.txt
-```
-
-### Profile with perf (Linux)
+### Linux perf
 ```bash
 perf record ./tests/test_performance
 perf report
 ```
 
+## Coverage & Testing
+
+See `@docs/COVERAGE_GUIDE.md` for coverage commands and test patterns.
+
 ## Common Issues
 
-### Test Port Conflicts
-Use unique port offsets for each test to avoid conflicts:
-```cpp
-start_server(1, 120);  // Uses port TEST_PORT + 120
-```
-
-### SSL Handshake Timeouts
-- Ensure certificates are valid
-- Check that SSL context is properly initialized
-- Verify server is listening before client connects
-
-### Memory Leaks in Tests
-- Always call `stop_server()` in test cleanup
-- Don't use 0-second timeouts that disconnect before server cleanup
-- Let connections complete gracefully
+See `@.claude/rules/common-pitfalls.md` for:
+- Test port conflicts
+- SSL handshake issues
+- Memory leaks in tests
+- Thread safety pitfalls

--- a/docs/PROJECT_RULES.md
+++ b/docs/PROJECT_RULES.md
@@ -24,7 +24,7 @@ make perf-test                                     # Run benchmarks
 
 ## CI Checks
 
-PRs must pass: ubuntu-24.04, ubi8, macos builds | ASan/UBSan | coverage | cppcheck | CodeQL
+PRs must pass: ubuntu-24.04, ubi8, macos builds | ASan/UBSan | TSan | coverage | cppcheck | CodeQL
 
 ## Architecture
 
@@ -45,6 +45,7 @@ PRs must pass: ubuntu-24.04, ubi8, macos builds | ASan/UBSan | coverage | cppche
 
 | Topic | File |
 |-------|------|
+| C++ style & patterns | `docs/CPP_STYLE.md` |
 | Coding standards | `docs/CODING_STANDARDS.md` |
 | Testing & coverage | `docs/COVERAGE_GUIDE.md` |
 | Performance rules | `docs/PERFORMANCE_GUIDE.md` |


### PR DESCRIPTION
## Summary
- Add `docs/CPP_STYLE.md` with C++ style patterns (performance anti-patterns, thread safety)
- Add TSan build instructions to `DEBUGGING.md`
- Add TSan to CI checks list in `PROJECT_RULES.md`
- Add `CPP_STYLE.md` to Reference Docs table

Makes C++ patterns available to all developers, all developers.

## Test plan
- [ ] Verify documentation renders correctly on GitHub
- [ ] Confirm cross-references are valid