### PR TITLE
Fix undefined behavior in Base64 encoding for signed char platforms

### DIFF
--- a/libiqxmlrpc/value_type.cc
+++ b/libiqxmlrpc/value_type.cc
@@ -419,12 +419,14 @@ void Binary_data::encode() const
 
   for( size_t i = 0; i < dsz; i += 3 )
   {
-    unsigned c = 0xff0000 & d[i] << 16;
+    // Cast to unsigned char to avoid undefined behavior when char is signed
+    // Left-shifting negative values (chars >= 128 on signed char platforms) is UB
+    unsigned c = static_cast<unsigned>(static_cast<unsigned char>(d[i])) << 16;
     add_base64_char( (c >> 18) & 0x3f );
 
     if( i+1 < dsz )
     {
-      c |= 0x00ff00 & d[i+1] << 8;
+      c |= static_cast<unsigned>(static_cast<unsigned char>(d[i+1])) << 8;
       add_base64_char( (c >> 12) & 0x3f );
     }
     else
@@ -436,7 +438,7 @@ void Binary_data::encode() const
 
     if( i+2 < dsz )
     {
-      c |= 0x0000ff & d[i+2];
+      c |= static_cast<unsigned>(static_cast<unsigned char>(d[i+2]));
       add_base64_char( (c >> 6) & 0x3f );
       add_base64_char( c & 0x3f );
     }


### PR DESCRIPTION
## Summary
- Fix undefined behavior when encoding bytes >= 128 on signed char platforms
- Add `static_cast<unsigned>(static_cast<unsigned char>(...))` before left-shift operations
- Add 3 test cases specifically for high-byte values (128-255)

## Problem
On platforms where `char` is signed (common on x86/x64), byte values 128-255 are stored as negative values (-128 to -1). Left-shifting negative values is undefined behavior in C++ (before C++20).

Example: `char(0xFF) << 16` where `char` is signed:
- `0xFF` stored as `-1`
- `-1` promoted to `int`: `0xFFFFFFFF`
- `(-1) << 16` = **undefined behavior**

## Solution
Cast to `unsigned char` first to get the byte value (0-255), then cast to `unsigned` for safe shifting:
```cpp
// Before (UB):
unsigned c = 0xff0000 & d[i] << 16;

// After (safe):
unsigned c = static_cast<unsigned>(static_cast<unsigned char>(d[i])) << 16;
```

## Agent Review Results
| Agent | Result |
|-------|--------|
| Performance | ✅ No regression |
| Security | ✅ Fix correct, no issues |
| Code Review | ✅ Consistent cast pattern |
| Code Simplifier | ✅ Minimal implementation |
| Coverage | ✅ Tests added for bytes >= 128 |

## Test plan
- [x] All 12 existing tests pass
- [x] New test `binary_encode_high_bytes` - bytes 0x80, 0xFF, 0xAB
- [x] New test `binary_encode_boundary_values` - boundary 127/128/129
- [x] New test `binary_encode_all_high_bytes` - all bytes 128-255