### PR TITLE
Potential fix for code scanning alert no. 21: Unused local variable

### DIFF
--- a/libiqxmlrpc/reactor_impl.h
+++ b/libiqxmlrpc/reactor_impl.h
@@ -133,7 +133,7 @@ void Reactor<Lock>::register_handler( Event_handler* eh, Event_mask mask )
 template <class Lock>
 void Reactor<Lock>::unregister_handler( Event_handler* eh, Event_mask mask )
 {
-  [[maybe_unused]] scoped_lock lk(lock);
+  scoped_lock lk(lock);
   hs_iterator i = find_handler_state( eh );
 
   if( i != end() )


### PR DESCRIPTION
Potential fix for [https://github.com/yarikmsu/libiqxmlrpc/security/code-scanning/21](https://github.com/yarikmsu/libiqxmlrpc/security/code-scanning/21)

In general, the correct way to handle RAII-based lock objects that are only used for their side-effects is to declare them as local variables without special attributes; their constructor/destructor will handle locking and unlocking even if the variable is never referenced again. The variable is conceptually “used” in that sense, and most tools accept that pattern.

Here, the best minimal fix that preserves functionality is to remove the `[[maybe_unused]]` attribute from the `scoped_lock lk(lock);` declaration in `Reactor<Lock>::unregister_handler`. This makes the line consistent with the similar use in `register_handler`, keeps the lock behavior intact, and avoids marking the variable as intentionally unused, which is what drew the CodeQL warning. No other logic, imports, or definitions need to change.

Concretely:
- Edit `libiqxmlrpc/reactor_impl.h`.
- In the `unregister_handler` template function, change line 136 from `[[maybe_unused]] scoped_lock lk(lock);` to `scoped_lock lk(lock);`.
- No new methods, headers, or other declarations are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
