### PR TITLE
Potential fix for code scanning alert no. 13: Commented-out code

### DIFF
--- a/libiqxmlrpc/server.h
+++ b/libiqxmlrpc/server.h
@@ -125,9 +125,6 @@ private:
 template <class Method_class>
 inline void register_method(Server& server, const std::string& name)
 {
-//  typedef typename Method_class::Help Help;
-//  Introspector::register_help_obj( meth_name, new Help );
-
   server.register_method(name, new Method_factory<Method_class>);
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/yarikmsu/libiqxmlrpc/security/code-scanning/13](https://github.com/yarikmsu/libiqxmlrpc/security/code-scanning/13)

In general, to fix commented-out code, either delete it if it is no longer needed, or reinstate it properly if it still represents required functionality. If you want to keep it as documentation, rewrite it clearly as an example (e.g., prefixed with “Example:” or adapted into non-compilable pseudo-code).

For this specific case, the simplest fix without changing functionality is to remove the two commented-out lines inside the `template <class Method_class> inline void register_method(...)` function in `libiqxmlrpc/server.h`. The function currently only needs to call `server.register_method(name, new Method_factory<Method_class>);`, so deleting the commented-out `typedef` and `Introspector::register_help_obj` lines will not alter runtime behavior and will satisfy the static analysis rule.

Only `libiqxmlrpc/server.h` needs to be edited; no new methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
