### PR TITLE
Add socket validation in Connection destructor

### DIFF
--- a/libiqxmlrpc/connection.cc
+++ b/libiqxmlrpc/connection.cc
@@ -15,7 +15,7 @@ Connection::Connection( const Socket& s ):
 
 Connection::~Connection()
 {
-  ::shutdown( sock.get_handler(), 2 );
+  sock.shutdown();  // Socket::shutdown() validates internally
   sock.close();
 }
 

--- a/libiqxmlrpc/socket.cc
+++ b/libiqxmlrpc/socket.cc
@@ -53,7 +53,9 @@ Socket::Socket( Socket::Handler h, const Inet_addr& addr ):
 
 void Socket::shutdown()
 {
-  ::shutdown( sock, 2 );
+  if (is_valid()) {
+    ::shutdown(sock, 2);
+  }
 }
 
 void Socket::close()

--- a/libiqxmlrpc/socket.h
+++ b/libiqxmlrpc/socket.h
@@ -32,6 +32,15 @@ public:
 
   Handler get_handler() const { return sock; }
 
+  //! Check if socket handler is valid (not closed/uninitialized).
+  bool is_valid() const {
+#ifdef _WINDOWS
+    return sock != INVALID_SOCKET;
+#else
+    return sock != -1;
+#endif
+  }
+
   void shutdown();
   void close();
 


### PR DESCRIPTION
## Summary

Add platform-safe socket validation to prevent silent EBADF errors in destructors.

## Changes

### 1. Add `Socket::is_valid()` method (`socket.h`)
```cpp
bool is_valid() const {
#ifdef _WINDOWS
  return sock != INVALID_SOCKET;
#else
  return sock != -1;
#endif
}
```

### 2. Update `Socket::shutdown()` (`socket.cc`)
```cpp
void Socket::shutdown()
{
  if (is_valid()) {
    ::shutdown(sock, 2);
  }
}
```

### 3. Simplify `Connection::~Connection()` (`connection.cc`)
```cpp
Connection::~Connection()
{
  sock.shutdown();  // Socket::shutdown() validates internally
  sock.close();
}
```

## Why This Approach

- **Platform-safe**: Uses `INVALID_SOCKET` on Windows, `-1` on Unix
- **Proper encapsulation**: Fix is in Socket class, benefiting all callers
- **Single source of truth**: Validation logic in one place
- **Clean destructors**: Connection just calls the safe API

## Test Plan
- [x] All 12 unit tests pass
- [x] CI validates on all platforms (ubuntu, ubi8, macos)
- [x] ASan/UBSan validates memory safety