### PR TITLE
Add SSL factory injection for HTTPS proxy testing (Phase 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,19 @@ if(ENABLE_COVERAGE)
     endif()
 endif()
 
+# Test hooks option - must be set before library compilation
+option(build_tests "Build tests?" ON)
+option(ENABLE_TESTING_HOOKS "Enable test hooks for SSL factory injection (test builds only)" OFF)
+if(ENABLE_TESTING_HOOKS)
+    if(NOT build_tests)
+        message(WARNING "ENABLE_TESTING_HOOKS is enabled but build_tests is OFF. "
+                        "Testing hooks are only useful when tests are built.")
+    endif()
+    add_compile_definitions(IQXMLRPC_TESTING)
+endif()
+
 add_subdirectory(libiqxmlrpc)
 
-option(build_tests "Build tests?" ON)
 if (build_tests)
 	enable_testing()
 	add_subdirectory(tests)

--- a/libiqxmlrpc/https_client.cc
+++ b/libiqxmlrpc/https_client.cc
@@ -55,6 +55,13 @@ http::Packet* Https_proxy_client_connection::do_process_session( const std::stri
 {
   setup_tunnel();
 
+#ifdef IQXMLRPC_TESTING
+  // Use factory if provided (for testing), otherwise create real SSL connection
+  if (ssl_factory_) {
+    return ssl_factory_(sock, non_blocking, s);
+  }
+#endif
+
   Https_client_connection https_conn(sock, non_blocking);
   https_conn.post_connect();
 


### PR DESCRIPTION
## Summary

Implements Phase 2 of the HTTPS Proxy Testing Plan: dependency injection for the SSL layer.

### Library Changes

| File | Change |
|------|--------|
| `https_client.h` | Add `SslConnectionFactory` type alias and `set_ssl_factory()` method |
| `https_client.cc` | Use factory when provided in `do_process_session()` |

### New Tests (3)

| Test | Coverage Target | Description |
|------|-----------------|-------------|
| `https_proxy_ssl_factory_success` | Lines 54-61 | Successful tunnel + mock SSL factory |
| `https_proxy_ssl_factory_parameters` | Line 60 | Verify factory receives correct params |
| `https_proxy_ssl_factory_exception` | Lines 59-60 | Exception propagation from factory |

### How It Works

```cpp
// Inject mock SSL factory for testing
conn.set_ssl_factory([](const Socket&, bool, const std::string&) -> http::Packet* {
  return new http::Packet(new http::Response_header(200, "OK"), mock_body);
});

// Now setup_tunnel() runs, then mock factory handles SSL layer
conn.process_session(req);
```

### Security Note

The factory injection is intended for testing only. Production code should not use `set_ssl_factory()`. See security review findings for potential compile-time guard recommendations.

## Test plan

- [x] `make check` - All 14 test suites pass (47 coverage tests)
- [x] New factory tests verify injection works correctly
- [x] Exception propagation tested
- [x] No regressions in existing tests