### PR TITLE
Add Coverity Scan integration for deep static analysis

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -25,6 +25,9 @@ on:
       # Only run on changes to library source code
       - 'libiqxmlrpc/**'
 
+env:
+  COVERITY_PROJECT: yarikmsu%2Flibiqxmlrpc
+
 jobs:
   coverity:
     name: Coverity Scan
@@ -40,6 +43,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        set -euo pipefail
         sudo apt-get update
         sudo apt-get install -y libboost-dev libboost-date-time-dev \
           libboost-thread-dev libboost-test-dev libboost-program-options-dev \
@@ -47,11 +51,13 @@ jobs:
 
     - name: Download Coverity Build Tool
       run: |
-        curl -fsSL https://scan.coverity.com/download/linux64 \
-          --data "token=${COV_TOKEN}&project=yarikmsu%2Flibiqxmlrpc" \
+        set -euo pipefail
+        curl --max-time 300 --connect-timeout 30 -fsSL \
+          https://scan.coverity.com/download/linux64 \
+          --data "token=${COV_TOKEN}&project=${COVERITY_PROJECT}" \
           -o coverity_tool.tgz
         # Verify download succeeded
-        if [ ! -s coverity_tool.tgz ]; then
+        if [[ ! -s coverity_tool.tgz ]]; then
           echo "::error::Failed to download Coverity tool"
           exit 1
         fi
@@ -61,7 +67,7 @@ jobs:
           exit 1
         }
         # Verify extraction succeeded
-        if [ ! -x coverity_tool/bin/cov-build ]; then
+        if [[ ! -x coverity_tool/bin/cov-build ]]; then
           echo "::error::Coverity tool extraction incomplete - cov-build not found"
           exit 1
         fi
@@ -70,6 +76,7 @@ jobs:
 
     - name: Configure
       run: |
+        set -euo pipefail
         mkdir build && cd build
         cmake -Dbuild_tests=ON \
           -DCMAKE_CXX_FLAGS="-DBOOST_TIMER_ENABLE_DEPRECATED -Wall -Wextra" \
@@ -77,11 +84,12 @@ jobs:
 
     - name: Build with Coverity
       run: |
+        set -euo pipefail
         export PATH="$(pwd)/coverity_tool/bin:$PATH"
         cd build
         cov-build --dir cov-int make -j$(nproc)
         # Verify build capture succeeded
-        if [ ! -f cov-int/build-log.txt ]; then
+        if [[ ! -f cov-int/build-log.txt ]]; then
           echo "::error::Coverity build capture failed - no build log"
           exit 1
         fi
@@ -90,22 +98,38 @@ jobs:
 
     - name: Submit to Coverity Scan
       run: |
+        set -euo pipefail
         cd build
         tar czvf libiqxmlrpc-cov.tgz cov-int
-        response=$(curl -fsSL \
+        # Submit with timeout and capture HTTP status
+        http_code=$(curl --max-time 600 --connect-timeout 30 -sSL \
           --form "token=${COV_TOKEN}" \
           --form "email=${COV_EMAIL}" \
           --form file=@libiqxmlrpc-cov.tgz \
           --form version="$(git rev-parse --short HEAD)" \
           --form description="Automated Coverity Scan from GitHub Actions" \
-          https://scan.coverity.com/builds?project=yarikmsu%2Flibiqxmlrpc)
-        echo "Coverity response: $response"
-        # Check for error indicators in response
-        if echo "$response" | grep -qiE "error|failed|exceeded|denied"; then
-          echo "::error::Coverity submission issue detected"
+          -w "%{http_code}" \
+          -o response.txt \
+          "https://scan.coverity.com/builds?project=${COVERITY_PROJECT}")
+        # Check HTTP status code
+        if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+          echo "::error::Coverity submission failed with HTTP $http_code"
           exit 1
         fi
-        echo "Submission successful"
+        # Check response for error indicators (sanitized output - no raw response)
+        if grep -qiE "error|failed|exceeded|denied|quota" response.txt; then
+          echo "::error::Coverity submission issue detected in response"
+          # Show only safe portions of response (filter out potential secrets)
+          grep -viE "token|key|secret|password|credential" response.txt || true
+          exit 1
+        fi
+        echo "Submission successful (HTTP $http_code)"
       env:
         COV_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
         COV_EMAIL: ${{ secrets.COVERITY_SCAN_EMAIL }}
+
+    - name: Cleanup
+      if: always()
+      run: |
+        rm -rf coverity_tool coverity_tool.tgz response.txt
+        rm -rf build/cov-int build/libiqxmlrpc-cov.tgz

--- a/docs/COVERITY_SETUP.md
+++ b/docs/COVERITY_SETUP.md
@@ -2,6 +2,10 @@
 
 Coverity Scan provides deep static analysis for free to open source projects.
 
+## Workflow Configuration
+
+The Coverity Scan workflow is defined in `.github/workflows/coverity.yml`.
+
 ## Setup Steps
 
 ### 1. Register Project at Coverity Scan
@@ -16,6 +20,8 @@ Coverity Scan provides deep static analysis for free to open source projects.
 1. Go to your project page on Coverity Scan
 2. Click "Project Settings"
 3. Copy the "Project Token"
+
+**Security Note:** The project token allows anyone to submit builds to your Coverity project. Keep it confidential and only store it as a GitHub secret. Never commit it to the repository or expose it in logs.
 
 ### 3. Add GitHub Secrets
 
@@ -54,3 +60,35 @@ Coverity provides:
 - Code paths showing how bugs occur
 - Fix recommendations
 - Trend analysis over time
+
+## Troubleshooting
+
+### "Failed to download Coverity tool"
+
+- Verify `COVERITY_SCAN_TOKEN` is set correctly in repository secrets
+- Check if the project is registered at https://scan.coverity.com
+- Ensure the token hasn't been regenerated (update the secret if so)
+
+### "Coverity submission failed with HTTP 4xx/5xx"
+
+- HTTP 401/403: Token is invalid or expired
+- HTTP 429: Submission quota exceeded - wait 24 hours
+- HTTP 5xx: Coverity service issue - retry later
+
+### "Coverity submission issue detected in response"
+
+- Check if daily submission quota is exceeded (free tier has limits)
+- Wait 24 hours or check quota at https://scan.coverity.com
+- Consider reducing push-triggered runs by limiting path filters
+
+### Workflow runs but no results appear
+
+- Allow 15-30 minutes for Coverity to process the submission
+- Check the email associated with `COVERITY_SCAN_EMAIL` for notifications
+- Verify the project is properly configured at Coverity Scan dashboard
+
+### Build capture shows few files
+
+- Ensure `cov-build` is in PATH before running make
+- Check `build/cov-int/build-log.txt` for capture details
+- Verify the build actually compiled source files (not just linked)

--- a/docs/PROJECT_RULES.md
+++ b/docs/PROJECT_RULES.md
@@ -26,7 +26,7 @@ make perf-test                                     # Run benchmarks
 
 PRs must pass: ubuntu-24.04, ubi8, macos | ASan/UBSan | TSan | Valgrind | Fuzz | coverage | cppcheck | clang-tidy | CodeQL
 
-Scheduled: Coverity Scan (weekly deep static analysis)
+Additional (non-blocking): Coverity Scan - weekly deep static analysis, results reviewed periodically
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

- Add `coverity.yml` workflow for weekly Coverity Scan
- Add `docs/COVERITY_SETUP.md` with setup instructions
- Update `PROJECT_RULES.md` to include Coverity in CI checks

## What is Coverity Scan?

Coverity Scan is a cloud-based deep static analysis service, **free for open source projects**. It finds bugs that other tools miss:

| Category | Examples |
|----------|----------|
| **Resource leaks** | Memory, file handles, sockets |
| **Null pointer dereferences** | Complex interprocedural paths |
| **Buffer overruns** | Array bounds violations |
| **Uninitialized variables** | Use before initialization |
| **Concurrency issues** | Race conditions, deadlocks |
| **API misuse** | Incorrect library usage |

## When Does It Run?

| Trigger | Frequency |
|---------|-----------|
| Schedule | Weekly (Sunday 00:00 UTC) |
| Manual | On-demand via workflow_dispatch |
| Push | On changes to `libiqxmlrpc/**` on master |

## Setup Required (One-time)

1. Register project at https://scan.coverity.com/projects/new
2. Add secrets to GitHub repository:
   - `COVERITY_SCAN_TOKEN` - Project token from Coverity
   - `COVERITY_SCAN_EMAIL` - Registration email

See `docs/COVERITY_SETUP.md` for detailed instructions.

## Test plan

- [ ] Workflow file validates (GitHub Actions syntax)
- [ ] After secrets are configured, manual trigger works
- [ ] Results appear on Coverity Scan dashboard