### PR TITLE
Fix EINTR handling in reactor poll/select implementations

### DIFF
--- a/libiqxmlrpc/reactor_poll_impl.cc
+++ b/libiqxmlrpc/reactor_poll_impl.cc
@@ -60,7 +60,8 @@ bool Reactor_poll_impl::poll(HandlerStateList& out, Reactor_base::Timeout to_ms)
     if( !code )
       return false;
 
-  } while (false);
+    break;  // Success - exit loop to process results
+  } while (true);
 
   for( unsigned i = 0; i < impl->pfd.size(); i++ )
   {

--- a/libiqxmlrpc/reactor_select_impl.cc
+++ b/libiqxmlrpc/reactor_select_impl.cc
@@ -65,7 +65,8 @@ bool Reactor_select_impl::poll(HandlerStateList& out, Reactor_base::Timeout to_m
     if( !code )
       return false;
 
-  } while (false);
+    break;  // Success - exit loop to process results
+  } while (true);
 
   for (const auto& handler : hs)
   {


### PR DESCRIPTION
## Summary

Fixes a 20-year-old bug in EINTR handling for `poll()` and `select()` reactor implementations.

The original code (from 2006 commit 2e91fce) intended to retry `poll()`/`select()` when interrupted by a signal (EINTR), but used `do { } while (false)` which caused the `continue` statement to exit the loop instead of retrying.

### The Bug

```cpp
do {
    int code = ::poll(...);
    if (code < 0) {
        if (errno == EINTR)
            continue;        // Intended to retry, but...
        throw network_error("poll()");
    }
    if (!code)
        return false;
} while (false);  // ...this exits immediately!
```

### Impact

When a signal interrupted `poll()`/`select()`, the code would:
- Fall through to process file descriptors with stale/uninitialized `revents`
- Potentially cause undefined behavior
- This was rarely triggered in normal operation (EINTR is uncommon outside of debugging)

### Fix

- Change `while (false)` → `while (true)` to enable actual retry on EINTR
- Add `break` statement on success to exit loop and process results

### Files Changed
- `libiqxmlrpc/reactor_poll_impl.cc`
- `libiqxmlrpc/reactor_select_impl.cc`

## Test Plan
- [x] All 15 tests pass (`make check`)
- [x] Code review agent verified fix correctness
- [x] Security agent confirmed no DoS risk from the loop

## References
- Fixes CodeQL alert #11: "Continue statement that does not continue"
- Original intent documented in commit 2e91fce (2006): "if poll or select returned with EINTR it will be restarted"