### PR TITLE
Change queue latency metrics from p95 to p90

### DIFF
--- a/tests/perf_utils.h
+++ b/tests/perf_utils.h
@@ -178,6 +178,7 @@ public:
   }
 
   int64_t p50() { return percentile(0.50); }
+  int64_t p90() { return percentile(0.90); }
   int64_t p95() { return percentile(0.95); }
   int64_t p99() { return percentile(0.99); }
   int64_t min() { sort(); return samples_.empty() ? 0 : samples_.front(); }

--- a/tests/test_perf_utils.cc
+++ b/tests/test_perf_utils.cc
@@ -137,6 +137,9 @@ BOOST_AUTO_TEST_CASE(percentile_interpolation)
     // With 100 samples, p50 should be around 50
     BOOST_CHECK_EQUAL(stats.p50(), 50);
 
+    // p90 should be around 90
+    BOOST_CHECK_EQUAL(stats.p90(), 90);
+
     // p95 should be around 95
     BOOST_CHECK_EQUAL(stats.p95(), 95);
 

--- a/tests/test_performance.cc
+++ b/tests/test_performance.cc
@@ -1272,17 +1272,17 @@ void benchmark_lockfree_queue() {
     "Lock-Free", lockfree_stats
   );
 
-  // Record p95 latencies as benchmark results for baseline tracking
-  // (p95 is more stable than p99 in CI environments with thread scheduling noise)
-  auto mutex_p95 = mutex_stats.p95();
-  auto lockfree_p95 = lockfree_stats.p95();
-  if (mutex_p95 > 0) {
+  // Record p90 latencies as benchmark results for baseline tracking
+  // (p90 is more stable than p95/p99 in CI environments with thread scheduling noise)
+  auto mutex_p90 = mutex_stats.p90();
+  auto lockfree_p90 = lockfree_stats.p90();
+  if (mutex_p90 > 0) {
     perf::ResultCollector::instance().add_result(
-      perf::BenchmarkResult("perf_mutex_queue_p95_latency", mutex_p95 / 1e6, 1));
+      perf::BenchmarkResult("perf_mutex_queue_p90_latency", mutex_p90 / 1e6, 1));
   }
-  if (lockfree_p95 > 0) {
+  if (lockfree_p90 > 0) {
     perf::ResultCollector::instance().add_result(
-      perf::BenchmarkResult("perf_lockfree_queue_p95_latency", lockfree_p95 / 1e6, 1));
+      perf::BenchmarkResult("perf_lockfree_queue_p90_latency", lockfree_p90 / 1e6, 1));
   }
 }
 


### PR DESCRIPTION
## Summary

Change both mutex and lockfree queue benchmarks from tracking p95 latency to p90 latency for better CI stability.

### Changes

| File | Change |
|------|--------|
| `tests/perf_utils.h` | Add `p90()` method to `LatencyStats` class |
| `tests/test_performance.cc` | Use `p90()` for both queue metrics |
| `tests/test_perf_utils.cc` | Add `p90()` unit test |

### Metrics Changed

| Before | After |
|--------|-------|
| `perf_mutex_queue_p95_latency` | `perf_mutex_queue_p90_latency` |
| `perf_lockfree_queue_p95_latency` | `perf_lockfree_queue_p90_latency` |

### Rationale

The p90 percentile is more stable in CI environments with thread scheduling noise. Lower percentiles have less variance from occasional scheduling delays, making baseline comparisons more reliable.

## Test Plan

- [x] All 15 tests pass (`make check`)
- [x] New `p90()` method has unit test
- [x] Code review agent: PASS
- [x] Security agent: PASS
- [x] Code simplifier agent: PASS