### PR TITLE
Tighten benchmark thresholds: 20%→15% default, 100%→75% relaxed

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,15 +25,16 @@ on:
       threshold:
         description: 'Default regression threshold percentage (must be positive number)'
         required: false
-        default: '20'
+        default: '15'
 
 env:
-  # 20% default threshold catches most regressions while allowing normal CI variance
-  REGRESSION_THRESHOLD: ${{ github.event.inputs.threshold || '20' }}
+  # 15% default threshold for tighter regression detection
+  REGRESSION_THRESHOLD: ${{ github.event.inputs.threshold || '15' }}
   # These 3 benchmarks have demonstrated CI failures due to inherent variance:
   # - perf_lockfree_queue_p90/p95_latency: Thread scheduling noise (50-95% variance)
   # - perf_string_to_int_new: Sub-nanosecond measurement (~1ns, 69% variance observed)
-  RELAXED_THRESHOLD: '100'
+  # 75% threshold catches real regressions while tolerating normal CI variance (~11%)
+  RELAXED_THRESHOLD: '75'
   RELAXED_BENCHMARKS: 'perf_lockfree_queue_p90_latency,perf_lockfree_queue_p95_latency,perf_string_to_int_new'
 
 jobs:

--- a/scripts/local_benchmark_compare.sh
+++ b/scripts/local_benchmark_compare.sh
@@ -3,8 +3,8 @@
 # Must be run from the repository root directory.
 #
 # Uses tiered thresholds:
-#   - Default: 20% for most benchmarks
-#   - Relaxed: 100% for high-variance benchmarks (queue latency P90/P95)
+#   - Default: 15% for most benchmarks
+#   - Relaxed: 75% for high-variance benchmarks (queue latency, sub-ns measurements)
 #
 # Usage:
 #   ./scripts/local_benchmark_compare.sh [threshold] [base_branch]
@@ -27,7 +27,7 @@ if ! command -v bc &>/dev/null; then
     exit 2
 fi
 
-THRESHOLD=${1:-20}
+THRESHOLD=${1:-15}
 BASE_BRANCH=${2:-master}
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -37,7 +37,8 @@ TMP_SCRIPTS="/tmp/benchmark_scripts_$$"
 # These 3 benchmarks have demonstrated CI failures due to inherent variance:
 # - perf_lockfree_queue_p90/p95_latency: Thread scheduling noise (50-95% variance)
 # - perf_string_to_int_new: Sub-nanosecond measurement (~1ns, 69% variance observed)
-RELAXED_THRESHOLD=100
+# 75% threshold catches real regressions while tolerating normal CI variance (~11%)
+RELAXED_THRESHOLD=75
 RELAXED_BENCHMARKS="perf_lockfree_queue_p90_latency,perf_lockfree_queue_p95_latency,perf_string_to_int_new"
 
 # Cross-platform nproc


### PR DESCRIPTION
## Summary

Tightens benchmark CI thresholds for better regression detection:
- Default: 20% → **15%** (25% more sensitive)
- Relaxed: 100% → **75%** (25% more sensitive)

## Validation

Both thresholds passed CI testing:

| Threshold | Change | CI Result | Benchmarks |
|-----------|--------|-----------|------------|
| Default | 20%→15% | ✅ Passed | 66 benchmarks |
| Relaxed | 100%→75% | ✅ Passed | 3 high-variance benchmarks |

The 5-run minimum selection provides stability that makes tighter thresholds viable.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/benchmark.yml` | `REGRESSION_THRESHOLD: '15'`, `RELAXED_THRESHOLD: '75'` |
| `scripts/local_benchmark_compare.sh` | `THRESHOLD=15`, `RELAXED_THRESHOLD=75` |

## Affected Benchmarks

**Default threshold (15%):** 66 benchmarks

**Relaxed threshold (75%):** 3 benchmarks
- `perf_lockfree_queue_p90_latency` - Thread scheduling noise
- `perf_lockfree_queue_p95_latency` - Thread scheduling noise
- `perf_string_to_int_new` - Sub-nanosecond measurement (~1ns)

## Test plan

- [x] CI benchmark check passes with 15% default threshold
- [x] CI benchmark check passes with 75% relaxed threshold
- [x] All 13 CI checks pass