### PR TITLE
Use auto with casts to reduce type duplication (modernize-use-auto)

### DIFF
--- a/libiqxmlrpc/socket.cc
+++ b/libiqxmlrpc/socket.cc
@@ -128,7 +128,7 @@ void Socket::send_shutdown( const char* data, size_t len )
 
 void Socket::bind( const Inet_addr& addr )
 {
-  const sockaddr* saddr = reinterpret_cast<const sockaddr*>(addr.get_sockaddr());
+  auto saddr = reinterpret_cast<const sockaddr*>(addr.get_sockaddr());
 
   if( ::bind( sock, saddr, sizeof(sockaddr_in) ) == -1 )
     throw network_error( "Socket::bind" );
@@ -156,7 +156,7 @@ Socket Socket::accept()
 
 bool Socket::connect( const iqnet::Inet_addr& peer_addr )
 {
-  const sockaddr* saddr = reinterpret_cast<const sockaddr*>(peer_addr.get_sockaddr());
+  auto saddr = reinterpret_cast<const sockaddr*>(peer_addr.get_sockaddr());
 
   int code = ::connect(sock, saddr, sizeof(sockaddr_in));
   bool wouldblock = false;

--- a/libiqxmlrpc/ssl_lib.cc
+++ b/libiqxmlrpc/ssl_lib.cc
@@ -196,8 +196,8 @@ set_server_cipher_options(SSL_CTX* ctx)
 int
 iqxmlrpc_SSL_verify(int prev_ok, X509_STORE_CTX* ctx)
 {
-  SSL* ssl = reinterpret_cast<SSL*>(X509_STORE_CTX_get_ex_data(ctx, SSL_get_ex_data_X509_STORE_CTX_idx()));
-  const ConnectionVerifier* v = reinterpret_cast<const ConnectionVerifier*>(SSL_get_ex_data(ssl, iqxmlrpc_ssl_data_idx));
+  auto ssl = reinterpret_cast<SSL*>(X509_STORE_CTX_get_ex_data(ctx, SSL_get_ex_data_X509_STORE_CTX_idx()));
+  auto v = reinterpret_cast<const ConnectionVerifier*>(SSL_get_ex_data(ssl, iqxmlrpc_ssl_data_idx));
   return v->verify(prev_ok, ctx);
 }
 

--- a/libiqxmlrpc/value_type.cc
+++ b/libiqxmlrpc/value_type.cc
@@ -455,7 +455,7 @@ void Binary_data::encode() const
 // Optimized decode using lookup table - no exceptions, direct buffer write
 void Binary_data::decode()
 {
-  const unsigned char* src = reinterpret_cast<const unsigned char*>(base64.data());
+  auto src = reinterpret_cast<const unsigned char*>(base64.data());
   const size_t src_len = base64.length();
 
   // Reserve space (decoded is at most 3/4 of base64 size)

--- a/libiqxmlrpc/xml_builder.cc
+++ b/libiqxmlrpc/xml_builder.cc
@@ -28,7 +28,7 @@ throwBuildError(T res, T err_res)
 XmlBuilder::Node::Node(XmlBuilder& w, const char* name):
   ctx(w)
 {
-  const xmlChar* xname = reinterpret_cast<const xmlChar*>(name);
+  auto xname = reinterpret_cast<const xmlChar*>(name);
   throwBuildError(xmlTextWriterStartElement(ctx.writer, xname), -1);
 }
 
@@ -64,7 +64,7 @@ XmlBuilder::~XmlBuilder()
 void
 XmlBuilder::add_textdata(const std::string& data)
 {
-  const xmlChar* xdata = reinterpret_cast<const xmlChar*>(data.c_str());
+  auto xdata = reinterpret_cast<const xmlChar*>(data.c_str());
   throwBuildError(xmlTextWriterWriteString(writer, xdata), -1);
 }
 
@@ -78,7 +78,7 @@ std::string
 XmlBuilder::content() const
 {
   xmlTextWriterFlush(writer);
-  const char* cdata = reinterpret_cast<const char*>(xmlBufferContent(buf));
+  auto cdata = reinterpret_cast<const char*>(xmlBufferContent(buf));
   return std::string(cdata, buf->use);
 }
 


### PR DESCRIPTION
## Summary
Apply clang-tidy `modernize-use-auto` fix for variables initialized with casts where the type is already explicit in the cast expression.

## Changes

| File | Line | Before | After |
|------|------|--------|-------|
| `xml_builder.cc` | 31, 67, 81 | `const xmlChar* x = reinterpret_cast<...>` | `auto x = reinterpret_cast<...>` |
| `ssl_lib.cc` | 199-200 | `SSL* ssl = reinterpret_cast<...>` | `auto ssl = reinterpret_cast<...>` |
| `socket.cc` | 131, 159 | `const sockaddr* saddr = reinterpret_cast<...>` | `auto saddr = reinterpret_cast<...>` |
| `value_type.cc` | 458 | `const unsigned char* src = reinterpret_cast<...>` | `auto src = reinterpret_cast<...>` |

## Why use auto here?
When initializing a variable with a cast, the type is already explicit in the cast expression. Using `auto` avoids repeating the type on both sides of the assignment:

```cpp
// Before: type appears twice
const xmlChar* xname = reinterpret_cast<const xmlChar*>(name);

// After: type appears once (in the cast)
auto xname = reinterpret_cast<const xmlChar*>(name);
```

## Test plan
- [x] `make check` passes (15/15 tests)
- [x] Local build succeeds without warnings
- [ ] CI passes all checks