### PR TITLE
Add override specifier to virtual method overrides (modernize-use-override)

### DIFF
--- a/tests/methods.h
+++ b/tests/methods.h
@@ -8,12 +8,12 @@ void register_user_methods(iqxmlrpc::Server& server);
 
 class serverctl_stop: public iqxmlrpc::Method {
 public:
-  void execute( const iqxmlrpc::Param_list&, iqxmlrpc::Value& );
+  void execute( const iqxmlrpc::Param_list&, iqxmlrpc::Value& ) override;
 };
 
 class serverctl_log: public iqxmlrpc::Method {
 public:
-  void execute( const iqxmlrpc::Param_list&, iqxmlrpc::Value& );
+  void execute( const iqxmlrpc::Param_list&, iqxmlrpc::Value& ) override;
 };
 
 void echo_method(iqxmlrpc::Method*, const iqxmlrpc::Param_list&, iqxmlrpc::Value&);
@@ -26,7 +26,7 @@ void sleep_method(iqxmlrpc::Method*, const iqxmlrpc::Param_list&, iqxmlrpc::Valu
 
 class Get_file: public iqxmlrpc::Method {
 public:
-  void execute( const iqxmlrpc::Param_list&, iqxmlrpc::Value& );
+  void execute( const iqxmlrpc::Param_list&, iqxmlrpc::Value& ) override;
 };
 
 #endif


### PR DESCRIPTION
## Summary
- Add `override` keyword to 3 `execute()` methods in test helper classes that override `Method::execute()`

## Changes
**tests/methods.h**
- `serverctl_stop::execute()` - added `override`
- `serverctl_log::execute()` - added `override`
- `Get_file::execute()` - added `override`

## Why This Matters
The `override` specifier is a C++11 best practice that:
- **Makes intent explicit**: clearly marks methods as overrides
- **Enables compile-time checking**: compiler errors if signature mismatches base class
- **Improves maintainability**: changes to base class virtual methods are caught immediately

## Test plan
- [x] `make check` passes (15/15 tests)
- [x] No compiler warnings