### PR TITLE
Simplify boolean expressions using De Morgan's theorem (readability-simplify-boolean-expr)

### DIFF
--- a/libiqxmlrpc/value_type.cc
+++ b/libiqxmlrpc/value_type.cc
@@ -602,11 +602,11 @@ Date_time::Date_time( const std::string& s ):
   tm_.tm_min  = parse_field(12, 2);         // mm
   tm_.tm_sec  = parse_field(15, 2);         // ss
 
-  if( (tm_.tm_year < 0) || !(tm_.tm_mon >= 0 && tm_.tm_mon <= 11) ||
-      !(tm_.tm_mday >= 1 && tm_.tm_mday <= 31) ||
-      !(tm_.tm_hour >= 0 && tm_.tm_hour <= 23) ||
-      !(tm_.tm_min >= 0 && tm_.tm_min <= 59) ||
-      !(tm_.tm_sec >= 0 && tm_.tm_sec <= 61)
+  if( (tm_.tm_year < 0) || (tm_.tm_mon < 0 || tm_.tm_mon > 11) ||
+      (tm_.tm_mday < 1 || tm_.tm_mday > 31) ||
+      (tm_.tm_hour < 0 || tm_.tm_hour > 23) ||
+      (tm_.tm_min < 0 || tm_.tm_min > 59) ||
+      (tm_.tm_sec < 0 || tm_.tm_sec > 61)
     )
     throw Malformed_iso8601();
 }


### PR DESCRIPTION
## Summary
- Apply De Morgan's theorem to simplify negated range checks in Date_time parsing

## Changes
**libiqxmlrpc/value_type.cc** (lines 605-609)

Before:
```cpp
if( (tm_.tm_year < 0) || !(tm_.tm_mon >= 0 && tm_.tm_mon <= 11) ||
    !(tm_.tm_mday >= 1 && tm_.tm_mday <= 31) ||
    !(tm_.tm_hour >= 0 && tm_.tm_hour <= 23) ||
    !(tm_.tm_min >= 0 && tm_.tm_min <= 59) ||
    !(tm_.tm_sec >= 0 && tm_.tm_sec <= 61)
  )
```

After:
```cpp
if( (tm_.tm_year < 0) || (tm_.tm_mon < 0 || tm_.tm_mon > 11) ||
    (tm_.tm_mday < 1 || tm_.tm_mday > 31) ||
    (tm_.tm_hour < 0 || tm_.tm_hour > 23) ||
    (tm_.tm_min < 0 || tm_.tm_min > 59) ||
    (tm_.tm_sec < 0 || tm_.tm_sec > 61)
  )
```

## Why This Matters
De Morgan's theorem: `!(A && B)` → `(!A || !B)`

The simplified form:
- **More explicit**: Shows the actual invalid range being checked
- **Easier to read**: No mental inversion needed
- **Same logic**: Both forms are mathematically equivalent

## Test plan
- [x] `make check` passes (15/15 tests)
- [x] clang-tidy `readability-simplify-boolean-expr` now reports 0 warnings for this file