### PR TITLE
Replace throw() with noexcept (modernize-use-noexcept)

### DIFF
--- a/libiqxmlrpc/http.h
+++ b/libiqxmlrpc/http.h
@@ -288,7 +288,7 @@ public:
     Packet( new Response_header(code, phrase), "" ),
     Exception( "HTTP: " + phrase ) {}
 
-  ~Error_response() throw() override = default;
+  ~Error_response() noexcept override = default;
 
   const Response_header* response_header() const
   {

--- a/libiqxmlrpc/ssl_lib.cc
+++ b/libiqxmlrpc/ssl_lib.cc
@@ -431,7 +431,7 @@ Ctx::prepare_sni(SSL* ssl)
 }
 
 // ----------------------------------------------------------------------------
-exception::exception() throw():
+exception::exception() noexcept:
   ssl_err( ERR_get_error() ),
   msg( ERR_reason_error_string(ssl_err) )
 {
@@ -439,7 +439,7 @@ exception::exception() throw():
 }
 
 
-exception::exception( unsigned long err ) throw():
+exception::exception( unsigned long err ) noexcept:
   ssl_err(err),
   msg()
 {
@@ -449,7 +449,7 @@ exception::exception( unsigned long err ) throw():
 }
 
 
-exception::exception( const std::string& msg_ ) throw():
+exception::exception( const std::string& msg_ ) noexcept:
   ssl_err(0),
   msg( msg_ )
 {

--- a/libiqxmlrpc/ssl_lib.h
+++ b/libiqxmlrpc/ssl_lib.h
@@ -149,13 +149,13 @@ class LIBIQXMLRPC_API exception: public std::exception {
   std::string msg;
 
 public:
-  exception() throw();
-  explicit exception( unsigned long ssl_err ) throw();
-  explicit exception( const std::string& msg ) throw();
-  virtual ~exception() throw() {}
+  exception() noexcept;
+  explicit exception( unsigned long ssl_err ) noexcept;
+  explicit exception( const std::string& msg ) noexcept;
+  ~exception() noexcept override = default;
 
-  const char*   what() const throw() { return msg.c_str(); }
-  unsigned long code() const throw() { return ssl_err; }
+  const char*   what() const noexcept override { return msg.c_str(); }
+  unsigned long code() const noexcept { return ssl_err; }
 };
 
 class LIBIQXMLRPC_API not_initialized: public ssl::exception {

--- a/libiqxmlrpc/value_type.cc
+++ b/libiqxmlrpc/value_type.cc
@@ -150,7 +150,7 @@ Array& Array::operator =( const Array& other )
 }
 
 
-void Array::swap( Array& other) throw()
+void Array::swap( Array& other) noexcept
 {
   values.swap(other.values);
 }
@@ -231,7 +231,7 @@ Struct::~Struct()
 }
 
 
-void Struct::swap( Struct& other ) throw()
+void Struct::swap( Struct& other ) noexcept
 {
   values.swap(other.values);
 }

--- a/libiqxmlrpc/value_type.h
+++ b/libiqxmlrpc/value_type.h
@@ -164,7 +164,7 @@ public:
   Array& operator =( const Array& );
   Array& operator =( Array&& other ) noexcept { swap(other); return *this; }
 
-  void swap(Array&) throw();
+  void swap(Array&) noexcept;
   Array* clone() const override;
   const std::string& type_name() const override;
   void apply_visitor(Value_type_visitor&) const override;
@@ -286,7 +286,7 @@ public:
   Struct& operator =( const Struct& );
   Struct& operator =( Struct&& other ) noexcept { swap(other); return *this; }
 
-  void swap(Struct&) throw();
+  void swap(Struct&) noexcept;
   Struct* clone() const override;
   const std::string& type_name() const override;
   void apply_visitor(Value_type_visitor&) const override;


### PR DESCRIPTION
## Summary
- Replace deprecated `throw()` dynamic exception specification with C++11 `noexcept`

## Changes

### libiqxmlrpc/ssl_lib.h & ssl_lib.cc
- `ssl::exception` constructors: `throw()` → `noexcept`
- `ssl::exception::~exception()`: `virtual ~exception() throw() {}` → `~exception() noexcept override = default;`
- `ssl::exception::what()`: added `override` to match `std::exception`
- `ssl::exception::code()`: `throw()` → `noexcept`

### libiqxmlrpc/http.h
- `Error_response::~Error_response()`: `throw()` → `noexcept`

### libiqxmlrpc/value_type.h & value_type.cc
- `Array::swap()`: `throw()` → `noexcept`
- `Struct::swap()`: `throw()` → `noexcept`

## Why This Matters
- `throw()` is deprecated in C++11 and removed in C++20
- `noexcept` enables better compiler optimizations
- `noexcept` is the modern way to specify non-throwing functions
- Added `override` to `what()` for correctness with `std::exception`

## Test plan
- [x] `make check` passes (15/15 tests)
- [x] No `throw()` remaining in codebase