### PR TITLE
Modernize for loops to range-based syntax

### DIFF
--- a/libiqxmlrpc/dispatcher_manager.cc
+++ b/libiqxmlrpc/dispatcher_manager.cc
@@ -149,10 +149,9 @@ Method* Method_dispatcher_manager::create_method(const Method::Data& mdata)
     throw Unknown_method(mdata.method_name);  // Sanitized in exception
   }
 
-  typedef Impl::DispatchersSet::iterator I;
-  for (I i = impl_->dispatchers.begin(); i != impl_->dispatchers.end(); ++i)
+  for (const auto& dispatcher : impl_->dispatchers)
   {
-    Method* tmp = (*i)->create_method(mdata);
+    Method* tmp = dispatcher->create_method(mdata);
     if (tmp)
       return tmp;
   }

--- a/libiqxmlrpc/reactor_poll_impl.cc
+++ b/libiqxmlrpc/reactor_poll_impl.cc
@@ -63,15 +63,15 @@ bool Reactor_poll_impl::poll(HandlerStateList& out, Reactor_base::Timeout to_ms)
     break;  // Success - exit loop to process results
   } while (true);
 
-  for( unsigned i = 0; i < impl->pfd.size(); i++ )
+  for (const auto& pfd_entry : impl->pfd)
   {
-    if( impl->pfd[i].revents )
+    if( pfd_entry.revents )
     {
-      Reactor_base::HandlerState hs(impl->pfd[i].fd);
-      hs.revents |= (impl->pfd[i].revents & POLLIN)  ? Reactor_base::INPUT : 0;
-      hs.revents |= (impl->pfd[i].revents & POLLOUT) ? Reactor_base::OUTPUT : 0;
-      hs.revents |= (impl->pfd[i].revents & POLLERR) ? Reactor_base::OUTPUT : 0;
-      hs.revents |= (impl->pfd[i].revents & POLLHUP) ? Reactor_base::OUTPUT : 0;
+      Reactor_base::HandlerState hs(pfd_entry.fd);
+      hs.revents |= (pfd_entry.revents & POLLIN)  ? Reactor_base::INPUT : 0;
+      hs.revents |= (pfd_entry.revents & POLLOUT) ? Reactor_base::OUTPUT : 0;
+      hs.revents |= (pfd_entry.revents & POLLERR) ? Reactor_base::OUTPUT : 0;
+      hs.revents |= (pfd_entry.revents & POLLHUP) ? Reactor_base::OUTPUT : 0;
       out.push_back( hs );
     }
   }

--- a/libiqxmlrpc/value_type_visitor.cc
+++ b/libiqxmlrpc/value_type_visitor.cc
@@ -53,11 +53,10 @@ void Print_value_visitor::do_visit_struct(const Struct& s)
 {
   out_ << "{";
 
-  typedef Struct::const_iterator CI;
-  for(CI i = s.begin(); i != s.end(); ++i )
+  for (const auto& [key, value] : s)
   {
-    out_ << " '" << i->first << "' => ";
-    i->second->apply_visitor(*this);
+    out_ << " '" << key << "' => ";
+    value->apply_visitor(*this);
     out_ << ",";
   }
 

--- a/libiqxmlrpc/value_type_xml.cc
+++ b/libiqxmlrpc/value_type_xml.cc
@@ -62,15 +62,14 @@ void Value_type_to_xml::do_visit_struct(const Struct& s)
 {
   XmlNode st(builder_, "struct");
 
-  typedef Struct::const_iterator CI;
   // Reuse single visitor instance like do_visit_array() does
   Value_type_to_xml vis(builder_, server_mode_);
 
-  for(CI i = s.begin(); i != s.end(); ++i )
+  for (const auto& [key, value] : s)
   {
     XmlNode member(builder_, "member");
-    add_textnode("name", i->first);
-    i->second->apply_visitor(vis);
+    add_textnode("name", key);
+    value->apply_visitor(vis);
   }
 }
 


### PR DESCRIPTION
## Summary
- Convert iterator-based loops to range-based for loops (clang-tidy modernize-loop-convert)
- Use C++17 structured bindings for map-like containers
- Part of clang-tidy modernization series from #123

## Changes
- `dispatcher_manager.cc`: Iterator loop → range-based
- `reactor_poll_impl.cc`: Index loop → range-based
- `value_type_visitor.cc`: Iterator loop → structured binding
- `value_type_xml.cc`: Iterator loop → structured binding

## Test plan
- [x] Build passes
- [x] All 15 tests pass
- [x] clang-tidy reports no modernize-loop-convert warnings