### PR TITLE
Apply clang-tidy modernization fixes (batch)

### DIFF
--- a/libiqxmlrpc/dispatcher_manager.cc
+++ b/libiqxmlrpc/dispatcher_manager.cc
@@ -161,9 +161,9 @@ Method* Method_dispatcher_manager::create_method(const Method::Data& mdata)
 
 void Method_dispatcher_manager::get_methods_list(Array& retval) const
 {
-  typedef Impl::DispatchersSet::const_iterator CI;
-  for (CI i = impl_->dispatchers.begin(); i != impl_->dispatchers.end(); ++i)
-    (*i)->get_methods_list(retval);
+  // cppcheck-suppress constVariableReference
+  for (const auto& dispatcher : impl_->dispatchers)
+    dispatcher->get_methods_list(retval);
 }
 
 void Method_dispatcher_manager::enable_introspection()

--- a/libiqxmlrpc/inet_addr.h
+++ b/libiqxmlrpc/inet_addr.h
@@ -39,7 +39,7 @@ public:
   Inet_addr( const std::string& host, int port = 0 );
   explicit Inet_addr( int port );
 
-  virtual ~Inet_addr() {}
+  virtual ~Inet_addr() = default;
 
   const struct sockaddr_in* get_sockaddr() const;
   const std::string& get_host_name() const;

--- a/libiqxmlrpc/net_except.cc
+++ b/libiqxmlrpc/net_except.cc
@@ -5,7 +5,7 @@
 #include <windows.h>
 #endif
 
-#include <string.h>
+#include <cstring>
 #include "net_except.h"
 
 namespace {

--- a/libiqxmlrpc/server_conn.h
+++ b/libiqxmlrpc/server_conn.h
@@ -121,7 +121,7 @@ public:
     reactor = r;
   }
 
-  void post_create( Transport* c )
+  void post_create( Transport* c ) override
   {
     c->set_server( server );
     c->set_reactor( reactor );

--- a/libiqxmlrpc/socket.h
+++ b/libiqxmlrpc/socket.h
@@ -28,7 +28,7 @@ public:
   //! Create object from existing socket handler.
   Socket( Handler, const Inet_addr& );
   //! Destructor. Does not close actual socket.
-  virtual ~Socket() {}
+  virtual ~Socket() = default;
 
   Handler get_handler() const { return sock; }
 

--- a/libiqxmlrpc/ssl_lib.cc
+++ b/libiqxmlrpc/ssl_lib.cc
@@ -207,9 +207,7 @@ iqxmlrpc_SSL_verify(int prev_ok, X509_STORE_CTX* ctx)
 // ConnectionVerifier
 //
 
-ConnectionVerifier::~ConnectionVerifier()
-{
-}
+ConnectionVerifier::~ConnectionVerifier() = default;
 
 int
 ConnectionVerifier::verify(bool prev_ok, X509_STORE_CTX* ctx) const
@@ -309,9 +307,7 @@ Ctx::Ctx():
 }
 
 
-Ctx::~Ctx()
-{
-}
+Ctx::~Ctx() = default;
 
 SSL_CTX*
 Ctx::context()

--- a/libiqxmlrpc/util.h
+++ b/libiqxmlrpc/util.h
@@ -79,7 +79,7 @@ public:
   explicit LockedBool(bool default_):
     val(default_) {}
 
-  ~LockedBool() {}
+  ~LockedBool() = default;
 
   operator bool()
   {

--- a/libiqxmlrpc/value_type.cc
+++ b/libiqxmlrpc/value_type.cc
@@ -12,7 +12,7 @@
 #include <charconv>
 #include <chrono>
 #include <ctime>
-#include <string.h>
+#include <cstring>
 
 namespace iqxmlrpc {
 namespace type_names {
@@ -225,10 +225,7 @@ Struct& Struct::operator =( const Struct& other )
 }
 
 
-Struct::~Struct()
-{
-  // unique_ptr elements are automatically destroyed by map destructor
-}
+Struct::~Struct() = default;
 
 
 void Struct::swap( Struct& other ) noexcept
@@ -269,7 +266,7 @@ bool Struct::has_field( const std::string& f ) const
 
 const Value& Struct::operator []( const std::string& f ) const
 {
-  const_iterator i = values.find(f);
+  auto i = values.find(f);
 
   if( i == values.end() )
     throw No_field( f );
@@ -280,7 +277,7 @@ const Value& Struct::operator []( const std::string& f ) const
 
 Value& Struct::operator []( const std::string& f )
 {
-  const_iterator i = values.find(f);
+  auto i = values.find(f);
 
   if( i == values.end() )
     throw No_field( f );

--- a/libiqxmlrpc/value_type.h
+++ b/libiqxmlrpc/value_type.h
@@ -53,7 +53,7 @@ enum class ValueTypeTag : unsigned char {
 //! Base type for XML-RPC types.
 class LIBIQXMLRPC_API Value_type {
 public:
-  virtual ~Value_type() {}
+  virtual ~Value_type() = default;
 
   virtual Value_type*  clone()  const = 0;
   virtual const std::string& type_name() const = 0;
@@ -225,7 +225,7 @@ public:
   // cppcheck-suppress noExplicitConstructor
   const_iterator( Array::Val_vector::const_iterator i_ ):  // NOLINT(google-explicit-constructor)
     i(i_) {}
-  ~const_iterator() {}
+  ~const_iterator() = default;
 
   const Value& operator *() const { return *(*i); }
   const Value* operator ->() const { return *i; }

--- a/libiqxmlrpc/value_type_visitor.cc
+++ b/libiqxmlrpc/value_type_visitor.cc
@@ -67,11 +67,10 @@ void Print_value_visitor::do_visit_array(const Array& a)
 {
   out_ << "[";
 
-  typedef Array::const_iterator CI;
-  for(CI i = a.begin(); i != a.end(); ++i )
+  for (const auto& elem : a)
   {
     out_ << " ";
-    i->apply_visitor(*this);
+    elem.apply_visitor(*this);
     out_ << ",";
   }
 

--- a/libiqxmlrpc/value_type_visitor.h
+++ b/libiqxmlrpc/value_type_visitor.h
@@ -16,7 +16,7 @@ namespace iqxmlrpc {
  */
 class LIBIQXMLRPC_API Value_type_visitor {
 public:
-  virtual ~Value_type_visitor() {}
+  virtual ~Value_type_visitor() = default;
 
   void visit_value(const Value_type& v)
   {

--- a/libiqxmlrpc/value_type_xml.cc
+++ b/libiqxmlrpc/value_type_xml.cc
@@ -78,11 +78,10 @@ void Value_type_to_xml::do_visit_array(const Array& a)
   XmlNode arr(builder_, "array");
   XmlNode data(builder_, "data");
 
-  typedef Array::const_iterator CI;
   Value_type_to_xml vis(builder_, server_mode_);
 
-  for(CI i = a.begin(); i != a.end(); ++i ) {
-    i->apply_visitor(vis);
+  for (const auto& elem : a) {
+    elem.apply_visitor(vis);
   }
 }
 


### PR DESCRIPTION
## Summary
Apply multiple clang-tidy modernization recommendations in a single PR.

## Changes Applied

| Check | Fix | Files |
|-------|-----|-------|
| `modernize-deprecated-headers` | `<string.h>` → `<cstring>` | net_except.cc, value_type.cc |
| `modernize-use-equals-default` | Empty destructors → `= default` | 8 files |
| `modernize-loop-convert` | Iterator loops → range-based for | 3 files |
| `modernize-use-auto` | Iterator decls → `auto` | value_type.cc |
| `modernize-use-override` | Add missing `override` | server_conn.h |

## Files Modified (12)
- dispatcher_manager.cc
- inet_addr.h
- net_except.cc
- server_conn.h
- socket.h
- ssl_lib.cc
- util.h
- value_type.cc
- value_type.h
- value_type_visitor.cc
- value_type_visitor.h
- value_type_xml.cc

## Test plan
- [x] Build passes
- [x] All 15 tests pass
- [x] clang-tidy should have fewer warnings

## Note
This PR does NOT include `modernize-make-unique` fixes (those are in PR #131).