### PR TITLE
Apply modernize-use-auto for redundant type declarations

### DIFF
--- a/libiqxmlrpc/https_client.cc
+++ b/libiqxmlrpc/https_client.cc
@@ -82,7 +82,7 @@ void Https_proxy_client_connection::setup_tunnel()
   }
   while( !resp_packet );
 
-  const http::Response_header* res_h =
+  const auto* res_h =
     static_cast<const http::Response_header*>(resp_packet->header());
 
   if( res_h->code() != 200 )

--- a/libiqxmlrpc/reactor_impl.h
+++ b/libiqxmlrpc/reactor_impl.h
@@ -247,7 +247,7 @@ void Reactor<Lock>::handle_user_events()
   scoped_lock lk(lock);
 
   handlers_states.copy_for_write();  // COW: copy if readers hold references
-  for( hs_iterator i = begin(); i != end(); ++i )
+  for( auto i = begin(); i != end(); ++i )
   {
     if( i->revents && (i->mask | i->revents) )
     {

--- a/libiqxmlrpc/value_parser.cc
+++ b/libiqxmlrpc/value_parser.cc
@@ -117,7 +117,7 @@ private:
   do_visit_element(const std::string& tagname) override
   {
     if (state_.change(tagname) == VALUES) {
-      Value_type* tmp = sub_build<Value_type*, ValueBuilder>();
+      auto* tmp = sub_build<Value_type*, ValueBuilder>();
       tmp = tmp ? tmp : new String("");
       proxy_->push_back(std::make_unique<Value>(tmp));
     }


### PR DESCRIPTION
## Summary
- Apply `modernize-use-auto` clang-tidy fixes where type is redundantly specified
- Follows C++ Core Guidelines ES.11: "Use auto to avoid redundant repetition of type names"

## Changes

| File | Line | Change |
|------|------|--------|
| `https_client.cc` | 85 | `const http::Response_header*` → `const auto*` (type in static_cast) |
| `reactor_impl.h` | 250 | `hs_iterator` → `auto` (iterator from begin()) |
| `value_parser.cc` | 120 | `Value_type*` → `auto*` (type in template argument) |

## Rationale
These changes apply `auto` only where the type is already explicitly stated on the right-hand side:
- Cast expressions: `static_cast<T*>(...)` 
- Template calls with explicit return type: `sub_build<T*, ...>()`
- Iterator initialization: `begin()` returns known iterator type

## Test plan
- [x] All existing tests pass (`make check`)
- [x] No compiler warnings
- [x] Security review: No concerns
- [x] Code review: Changes follow ES.11 guidelines