### PR TITLE
Use emplace_back instead of push_back in request parser

### DIFF
--- a/libiqxmlrpc/request_parser.cc
+++ b/libiqxmlrpc/request_parser.cc
@@ -44,7 +44,7 @@ RequestBuilder::do_visit_element(const std::string& tagname)
     break;
 
   case VALUE:
-    params_.push_back(sub_build<Value_type*, ValueBuilder>(true));
+    params_.emplace_back(sub_build<Value_type*, ValueBuilder>(true));
     break;
   }
 }


### PR DESCRIPTION
## Summary
- Fix `modernize-use-emplace` clang-tidy warning
- Use `emplace_back` instead of `push_back` for parameter list

## Change
**File:** `libiqxmlrpc/request_parser.cc:47`

```cpp
// Before
params_.push_back(sub_build<Value_type*, ValueBuilder>(true));

// After
params_.emplace_back(sub_build<Value_type*, ValueBuilder>(true));
```

## Rationale
`emplace_back` constructs the `Value` object directly in the vector, avoiding a temporary object creation and subsequent move/copy that `push_back` would require.

## Test plan
- [x] All existing tests pass (`make check`)
- [x] No compiler warnings