### PR TITLE
Add default case to switch statements in parsers

### DIFF
--- a/libiqxmlrpc/request_parser.cc
+++ b/libiqxmlrpc/request_parser.cc
@@ -46,6 +46,9 @@ RequestBuilder::do_visit_element(const std::string& tagname)
   case VALUE:
     params_.emplace_back(sub_build<Value_type*, ValueBuilder>(true));
     break;
+
+  default:
+    break;
   }
 }
 

--- a/libiqxmlrpc/response_parser.cc
+++ b/libiqxmlrpc/response_parser.cc
@@ -47,6 +47,9 @@ ResponseBuilder::do_visit_element(const std::string& tagname)
   case FAULT_RESPONSE_VALUE:
     parse_fault();
     break;
+
+  default:
+    break;
   }
 }
 


### PR DESCRIPTION
## Summary
- Add `default: break;` to switch statements in request and response parsers
- Fix `bugprone-switch-missing-default-case` clang-tidy warnings

## Changes
| File | Line |
|------|------|
| `request_parser.cc` | 41 |
| `response_parser.cc` | 42 |

## Rationale
The state machine pattern used in these parsers intentionally ignores unhandled states (they're processed elsewhere or represent intermediate transitions). Adding an explicit `default: break;` documents this intent while satisfying the clang-tidy check.

## Test plan
- [x] All existing tests pass (`make check`)
- [x] No compiler warnings