### PR TITLE
Fix performance-unnecessary-value-param warnings

### DIFF
--- a/libiqxmlrpc/http.cc
+++ b/libiqxmlrpc/http.cc
@@ -213,7 +213,7 @@ void Header::register_validator(
   Header::Option_validator_fn fn,
   Verification_level level)
 {
-  Option_validator v = { level, fn };
+  Option_validator v = { level, std::move(fn) };
   validators_.insert(std::make_pair(name, v));
 }
 

--- a/libiqxmlrpc/value.cc
+++ b/libiqxmlrpc/value.cc
@@ -78,7 +78,7 @@ Value::Value( Value&& v ) noexcept :
   v.value = nullptr;
 }
 
-Value::Value( Nil n ):
+Value::Value( const Nil& n ):
   value( n.clone() )
 {
 }

--- a/libiqxmlrpc/value.h
+++ b/libiqxmlrpc/value.h
@@ -34,7 +34,7 @@ public:
   Value( const Value& );
   Value( Value&& ) noexcept;
   // cppcheck-suppress noExplicitConstructor
-  Value( Nil );
+  Value( const Nil& );
   // cppcheck-suppress noExplicitConstructor
   Value( int );
   // cppcheck-suppress noExplicitConstructor


### PR DESCRIPTION
## Summary
- Fix `performance-unnecessary-value-param` clang-tidy warnings
- 2 warnings fixed

## Changes

| File | Change |
|------|--------|
| `value.h:37` | `Value(Nil)` → `Value(const Nil&)` |
| `value.cc:81` | `Value::Value(Nil n)` → `Value::Value(const Nil& n)` |
| `http.cc:216` | Use `std::move(fn)` for function parameter |

## Rationale
- **Nil parameter**: `Nil` is a polymorphic class inheriting from `Value_type`. Passing by const reference avoids unnecessary copy and potential slicing.
- **fn parameter**: The `std::function` is only used once (copied into a struct), so `std::move` avoids an extra copy.

## Test plan
- [x] All existing tests pass (`make check`)
- [x] No compiler warnings