### PR TITLE
Add local clang-tidy target for parallel static analysis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,61 @@ endif (build_docs)
 add_custom_target(clog
 	COMMAND git log > ChangeLog)
 
+# clang-tidy target for parallel static analysis
+# Requires: cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+# Usage: make clang-tidy
+# Search common locations including Homebrew LLVM on macOS
+set(LLVM_SEARCH_PATHS
+    /opt/homebrew/opt/llvm/bin
+    /usr/local/opt/llvm/bin
+    /usr/lib/llvm-18/bin
+    /usr/lib/llvm-17/bin
+)
+find_program(RUN_CLANG_TIDY NAMES run-clang-tidy run-clang-tidy.py
+    HINTS ${LLVM_SEARCH_PATHS})
+find_program(CLANG_TIDY_BIN NAMES clang-tidy
+    HINTS ${LLVM_SEARCH_PATHS})
+
+# On macOS with Homebrew LLVM, we need to specify the SDK path
+set(CLANG_TIDY_EXTRA_ARGS "")
+if(APPLE)
+    execute_process(
+        COMMAND xcrun --show-sdk-path
+        OUTPUT_VARIABLE MACOS_SDK_PATH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        RESULT_VARIABLE XCRUN_RESULT)
+    if(XCRUN_RESULT EQUAL 0 AND MACOS_SDK_PATH)
+        set(CLANG_TIDY_EXTRA_ARGS "-extra-arg=-isysroot${MACOS_SDK_PATH}")
+    endif()
+endif()
+
+if(RUN_CLANG_TIDY AND CLANG_TIDY_BIN)
+    add_custom_target(clang-tidy
+        COMMAND ${RUN_CLANG_TIDY}
+            -clang-tidy-binary ${CLANG_TIDY_BIN}
+            -p ${CMAKE_BINARY_DIR}
+            -header-filter=libiqxmlrpc/
+            ${CLANG_TIDY_EXTRA_ARGS}
+            "libiqxmlrpc/.*\\.cc"
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        COMMENT "Running clang-tidy in parallel..."
+        VERBATIM)
+elseif(CLANG_TIDY_BIN)
+    # Fallback: use find/xargs if run-clang-tidy not available
+    add_custom_target(clang-tidy
+        COMMAND find ${CMAKE_SOURCE_DIR}/libiqxmlrpc -name "*.cc" -print0 |
+            xargs -0 -P $$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4) -n 1
+            ${CLANG_TIDY_BIN} -p ${CMAKE_BINARY_DIR} -header-filter=libiqxmlrpc/ ${CLANG_TIDY_EXTRA_ARGS}
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        COMMENT "Running clang-tidy (parallel fallback)..."
+        VERBATIM)
+else()
+    message(STATUS "clang-tidy not found, 'make clang-tidy' target disabled")
+endif()
+if(CLANG_TIDY_BIN AND NOT CMAKE_EXPORT_COMPILE_COMMANDS)
+    message(STATUS "Note: 'make clang-tidy' requires CMAKE_EXPORT_COMPILE_COMMANDS=ON")
+endif()
+
 add_custom_target(dist
 	COMMAND git archive --prefix=libiqxmlrpc-${Libiqxmlrpc_VERSION}/ --format=tar HEAD | bzip2 > libiqxmlrpc-${Libiqxmlrpc_VERSION}.tar.bz2
 	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})


### PR DESCRIPTION
## Summary
- Add `make clang-tidy` target to run static analysis locally, matching CI behavior
- Support Homebrew LLVM on macOS (ARM and Intel) and system LLVM on Linux
- Provide parallel execution via `run-clang-tidy` with fallback to `find/xargs`
- Auto-detect macOS SDK path for Homebrew LLVM compatibility
- Display helpful status message when `CMAKE_EXPORT_COMPILE_COMMANDS` is not enabled

## Motivation
Running clang-tidy locally allows developers to catch static analysis issues before pushing, reducing CI iteration time and improving code quality.

## Usage
```bash
cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
make clang-tidy
```

## Test plan
- [x] `make check` passes
- [x] Verified `make clang-tidy` works on macOS with Homebrew LLVM
- [x] Code review checklist passed
- [x] Security checklist passed
- [x] Code simplifier agent passed