### PR TITLE
Fix bugprone-unchecked-optional-access warning

### DIFF
--- a/libiqxmlrpc/inet_addr.cc
+++ b/libiqxmlrpc/inet_addr.cc
@@ -149,6 +149,9 @@ Inet_addr::get_sockaddr() const
     }
   });
 
+  if (!impl_->sa.has_value()) {
+    throw network_error("Socket address initialization failed", false);
+  }
   return &(*impl_->sa);
 }
 


### PR DESCRIPTION
## Summary
- Add explicit `has_value()` check before dereferencing `std::optional` in `Inet_addr::get_sockaddr()`
- Fixes clang-tidy `bugprone-unchecked-optional-access` warning

## Details
While the check is theoretically unreachable (the `init_sockaddr()` function either succeeds and sets the optional, or throws an exception), adding explicit validation:
- Satisfies static analysis tools
- Prevents undefined behavior if future refactoring changes the control flow
- Documents the expected invariant

## Test plan
- [x] `make check` passes (16/16 tests)
- [x] Code review: Approved
- [x] Security review: No vulnerabilities found