### PR TITLE
Fix bugprone-assignment-in-if-condition warnings

### DIFF
--- a/libiqxmlrpc/client_opts.h
+++ b/libiqxmlrpc/client_opts.h
@@ -43,7 +43,8 @@ public:
 
   void set_timeout( int seconds )
   {
-    if( (timeout_ = seconds) > 0 )
+    timeout_ = seconds;
+    if (timeout_ > 0)
       non_blocking_flag_ = true;
   }
 

--- a/libiqxmlrpc/http_client.cc
+++ b/libiqxmlrpc/http_client.cc
@@ -59,7 +59,8 @@ void Http_client_connection::handle_input( bool& )
   // cppcheck-suppress knownConditionTrueFalse
   for( size_t sz = read_buf_sz(); (sz == read_buf_sz()) && !resp_packet ; )
   {
-    if( !(sz = recv( read_buf(), read_buf_sz() )) )
+    sz = recv( read_buf(), read_buf_sz() );
+    if (sz == 0)
       throw iqnet::network_error( "Connection closed by peer.", false );
 
     resp_packet = read_response( std::string(read_buf(), sz) );

--- a/libiqxmlrpc/https_client.cc
+++ b/libiqxmlrpc/https_client.cc
@@ -105,7 +105,8 @@ void Https_proxy_client_connection::handle_input( bool& )
 {
   for( size_t sz = read_buf_sz(); (sz == read_buf_sz()) && !resp_packet ; )
   {
-    if( !(sz = recv( read_buf(), read_buf_sz() )) )
+    sz = recv( read_buf(), read_buf_sz() );
+    if (sz == 0)
       throw iqnet::network_error( "Connection closed by peer.", false );
 
     resp_packet.reset( read_response(std::string(read_buf(), sz), true) );

--- a/libiqxmlrpc/socket.cc
+++ b/libiqxmlrpc/socket.cc
@@ -17,7 +17,8 @@ Socket::Socket():
   sock(-1),
   peer()
 {
-  if( (sock = socket( PF_INET, SOCK_STREAM, IPPROTO_TCP )) == -1 )
+  sock = socket( PF_INET, SOCK_STREAM, IPPROTO_TCP );
+  if (sock == -1)
     throw network_error( "Socket::Socket" );
 
 #ifndef WIN32


### PR DESCRIPTION
## Summary
- Separate assignments from `if` conditions to fix 4 clang-tidy warnings
- All changes are semantically equivalent with no behavior changes

## Changes
| File | Function | Pattern Fixed |
|------|----------|---------------|
| `client_opts.h` | `set_timeout()` | `if((x = y) > 0)` → `x = y; if(x > 0)` |
| `socket.cc` | `Socket()` | `if((sock = socket()) == -1)` → `sock = socket(); if(sock == -1)` |
| `http_client.cc` | `handle_input()` | `if(!(sz = recv()))` → `sz = recv(); if(sz == 0)` |
| `https_client.cc` | `handle_input()` | `if(!(sz = recv()))` → `sz = recv(); if(sz == 0)` |

## Test plan
- [x] `make check` passes (16/16 tests)
- [x] Code review: All changes semantically equivalent