### PR TITLE
Handle strftime and time function return values

### DIFF
--- a/libiqxmlrpc/http.cc
+++ b/libiqxmlrpc/http.cc
@@ -607,8 +607,8 @@ std::string Response_header::current_date()
   gmtime_r(&now, &gmt);
 #endif
   char buf[30];  // "Fri, 10 Jan 2026 12:30:45 GMT" = 29 chars + null
-  std::strftime(buf, sizeof(buf), "%a, %d %b %Y %H:%M:%S GMT", &gmt);
-  return std::string(buf);
+  size_t len = std::strftime(buf, sizeof(buf), "%a, %d %b %Y %H:%M:%S GMT", &gmt);
+  return std::string(buf, len);
 }
 
 std::string Response_header::dump_head() const

--- a/libiqxmlrpc/value_type.cc
+++ b/libiqxmlrpc/value_type.cc
@@ -553,9 +553,11 @@ Date_time::Date_time( bool use_lt ):
   }
 #else
   if (use_lt) {
-    localtime_r(&time, &tm_);
+    // Return value check: localtime_r only fails with invalid time_t,
+    // which can't happen from system_clock::now()
+    (void)localtime_r(&time, &tm_);
   } else {
-    gmtime_r(&time, &tm_);
+    (void)gmtime_r(&time, &tm_);
   }
 #endif
 }
@@ -632,8 +634,8 @@ const std::string& Date_time::to_string() const
   if( cache.empty() )
   {
     char s[18];
-    strftime( s, 18, "%Y%m%dT%H:%M:%S", &tm_ );
-    cache = std::string( s, 17 );
+    size_t len = strftime( s, sizeof(s), "%Y%m%dT%H:%M:%S", &tm_ );
+    cache = std::string( s, len );
   }
 
   return cache;


### PR DESCRIPTION
## Summary
Fix `cert-err33-c` warnings by properly handling return values from time functions.

## Changes
| File | Function | Fix |
|------|----------|-----|
| `http.cc` | `make_date()` | Use `strftime()` return to construct string (also more efficient) |
| `value_type.cc` | `Date_time::to_string()` | Use `strftime()` return to construct string |
| `value_type.cc` | `Date_time()` constructor | Explicitly ignore `localtime_r`/`gmtime_r` returns with comment |

## Why `(void)` cast for time functions?
The `localtime_r` and `gmtime_r` functions only fail with invalid `time_t` values. Since we get time from `std::chrono::system_clock::now()`, the value is always valid. The `(void)` cast with comment documents this intentional choice.

## Test plan
- [x] `make check` passes (16/16 tests)
- [x] strftime return values now used correctly