### PR TITLE
Return const from postfix increment/decrement operators

### DIFF
--- a/libiqxmlrpc/value_type.h
+++ b/libiqxmlrpc/value_type.h
@@ -230,8 +230,8 @@ public:
   const Value& operator *() const { return *(*i); }
   const Value* operator ->() const { return *i; }
 
-  const_iterator operator ++( int ) { return const_iterator(i++); }
-  const_iterator operator --( int ) { return const_iterator(i--); }
+  const const_iterator operator ++( int ) { return const_iterator(i++); }
+  const const_iterator operator --( int ) { return const_iterator(i--); }
 
   const_iterator& operator ++() { ++i; return *this; }
   const_iterator& operator --() { --i; return *this; }


### PR DESCRIPTION
## Summary
Fix `cert-dcl21-cpp` warnings by returning `const` objects from postfix `operator++` and `operator--`.

## Why?
Postfix increment/decrement operators return the *old* value as a temporary. Allowing modification of this temporary (e.g., `(i++)++`) is meaningless and likely a bug. Returning `const` prevents this at compile time.

## Changes
```cpp
// Before
const_iterator operator ++( int ) { return const_iterator(i++); }
const_iterator operator --( int ) { return const_iterator(i--); }

// After  
const const_iterator operator ++( int ) { return const_iterator(i++); }
const const_iterator operator --( int ) { return const_iterator(i--); }
```

## Test plan
- [x] `make check` passes (16/16 tests)
- [x] No behavior change - only prevents invalid usage patterns