### PR TITLE
Fix socket FD leak in firewall rejection path (CID 641369)

### DIFF
--- a/libiqxmlrpc/acceptor.cc
+++ b/libiqxmlrpc/acceptor.cc
@@ -68,6 +68,7 @@ void Acceptor::accept()
       new_sock.shutdown();
     }
 
+    new_sock.close();  // Close socket to prevent file descriptor leak
     return;
   }
 


### PR DESCRIPTION
## Summary
- Fixed socket file descriptor leak when firewall rejects a connection (Coverity CID 641369)
- The `Socket` destructor intentionally does not close the socket (ownership pattern), so explicit `close()` is required
- Without this fix, an attacker could exhaust server FDs by repeatedly connecting and getting rejected

## Changes
- `libiqxmlrpc/acceptor.cc`: Added `new_sock.close()` after shutdown in firewall rejection path
- `tests/test_integration_security.cc`: Added two test cases covering both code paths (with and without firewall message)

## Test plan
- [x] `make check` passes (16/16 tests)
- [x] New tests verify FD cleanup:
  - `firewall_blocks_connection_no_leak` - tests `shutdown()` path
  - `firewall_blocks_with_message_no_leak` - tests `send_shutdown()` path
- [x] Tests make 10 connection attempts each, then verify server still works