### PR TITLE
Reduce enum sizes with explicit underlying type

### DIFF
--- a/libiqxmlrpc/http.h
+++ b/libiqxmlrpc/http.h
@@ -8,6 +8,7 @@
 #include "inet_addr.h"
 #include "xheaders.h"
 
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <memory>
@@ -25,7 +26,7 @@ class Auth_Plugin_base;
 namespace http {
 
 //! The level of HTTP sanity checks.
-enum Verification_level { HTTP_CHECK_WEAK, HTTP_CHECK_STRICT };
+enum Verification_level : std::uint8_t { HTTP_CHECK_WEAK, HTTP_CHECK_STRICT };
 
 #ifdef _MSC_VER
 #pragma warning(push)

--- a/libiqxmlrpc/reactor.h
+++ b/libiqxmlrpc/reactor.h
@@ -8,6 +8,7 @@
 #include "net_except.h"
 #include "socket.h"
 
+#include <cstdint>
 #include <list>
 #include <memory>
 
@@ -50,7 +51,7 @@ public:
       network_error( "iqnet::Reactor: no handlers given.", false ) {}
   };
 
-  enum Event_mask { INPUT=1, OUTPUT=2 };
+  enum Event_mask : std::uint8_t { INPUT=1, OUTPUT=2 };
 
   struct HandlerState {
     Socket::Handler fd;

--- a/libiqxmlrpc/request_parser.cc
+++ b/libiqxmlrpc/request_parser.cc
@@ -1,6 +1,7 @@
 //  Libiqxmlrpc - an object-oriented XML-RPC solution.
 //  Copyright (C) 2011 Anton Dedov
 
+#include <cstdint>
 #include <stdexcept>
 #include "except.h"
 #include "request_parser.h"
@@ -8,7 +9,7 @@
 
 namespace iqxmlrpc {
 
-enum RequestBuilderState {
+enum RequestBuilderState : std::uint8_t {
   NONE,
   METHOD_CALL,
   METHOD_NAME,

--- a/libiqxmlrpc/response_parser.cc
+++ b/libiqxmlrpc/response_parser.cc
@@ -1,6 +1,7 @@
 //  Libiqxmlrpc - an object-oriented XML-RPC solution.
 //  Copyright (C) 2011 Anton Dedov
 
+#include <cstdint>
 #include <stdexcept>
 #include "except.h"
 #include "response_parser.h"
@@ -8,7 +9,7 @@
 
 namespace iqxmlrpc {
 
-enum ResponseBuilderState {
+enum ResponseBuilderState : std::uint8_t {
   NONE,
   RESPONSE,
   OK_RESPONSE,

--- a/libiqxmlrpc/ssl_connection.h
+++ b/libiqxmlrpc/ssl_connection.h
@@ -9,6 +9,7 @@
 #include "reactor.h"
 #include "ssl_lib.h"
 
+#include <cstdint>
 #include <openssl/ssl.h>
 
 namespace iqnet {
@@ -78,7 +79,7 @@ protected:
 class LIBIQXMLRPC_API Reaction_connection: public ssl::Connection {
   Reactor_base* reactor;
 
-  enum State { EMPTY, ACCEPTING, CONNECTING, READING, WRITING, SHUTDOWN };
+  enum State : std::uint8_t { EMPTY, ACCEPTING, CONNECTING, READING, WRITING, SHUTDOWN };
   State state = EMPTY;
 
   char* recv_buf = nullptr;

--- a/libiqxmlrpc/ssl_lib.h
+++ b/libiqxmlrpc/ssl_lib.h
@@ -6,6 +6,7 @@
 
 #include "api_export.h"
 
+#include <cstdint>
 #include <memory>
 #include <openssl/ssl.h>
 #include <stdexcept>
@@ -31,7 +32,7 @@ void LIBIQXMLRPC_API throw_io_exception( SSL*, int ret );
     These states occur frequently in non-blocking SSL I/O and using
     exceptions for normal control flow is expensive.
 */
-enum class SslIoResult {
+enum class SslIoResult : std::uint8_t {
   OK,               //!< Operation completed successfully
   WANT_READ,        //!< Need to wait for socket readable, then retry
   WANT_WRITE,       //!< Need to wait for socket writable, then retry

--- a/libiqxmlrpc/value_parser.cc
+++ b/libiqxmlrpc/value_parser.cc
@@ -1,6 +1,7 @@
 //  Libiqxmlrpc - an object-oriented XML-RPC solution.
 //  Copyright (C) 2011 Anton Dedov
 
+#include <cstdint>
 #include <stdexcept>
 #include "except.h"
 #include "num_conv.h"
@@ -39,7 +40,7 @@ public:
   }
 
 private:
-  enum State {
+  enum State : std::uint8_t {
     NONE,
     MEMBER,
     NAME_READ,
@@ -107,7 +108,7 @@ public:
   }
 
 private:
-  enum State {
+  enum State : std::uint8_t {
     NONE,
     DATA,
     VALUES
@@ -129,7 +130,7 @@ private:
 
 } // anonymous namespace
 
-enum ValueBuilderState {
+enum ValueBuilderState : std::uint8_t {
   VALUE,
   STRING,
   INT,


### PR DESCRIPTION
## Summary
- Add `: std::uint8_t` underlying type to 9 enums that use few values
- Reduces enum size from 4 bytes to 1 byte for better cache efficiency
- Fixes all `performance-enum-size` clang-tidy warnings

## Changes

| File | Enum | Values |
|------|------|--------|
| `http.h` | `Verification_level` | 2 |
| `reactor.h` | `Event_mask` | 2 |
| `ssl_connection.h` | `State` | 6 |
| `ssl_lib.h` | `SslIoResult` | 5 |
| `request_parser.cc` | `RequestBuilderState` | 6 |
| `response_parser.cc` | `ResponseBuilderState` | 7 |
| `value_parser.cc` | `State` (StructBuilder) | 4 |
| `value_parser.cc` | `State` (ArrayBuilder) | 3 |
| `value_parser.cc` | `ValueBuilderState` | 11 |

## Notes
- All values fit well within `uint8_t` range (0-255)
- Source-compatible change (no user code changes needed)
- ABI change for public enums requires recompilation

## Test plan
- [x] `make check` passes (all 16 tests)
- [x] No compiler warnings
- [x] Security review passed
- [x] Code review passed