### PR TITLE
Suppress concurrency-mt-unsafe warning for gethostbyname

### DIFF
--- a/libiqxmlrpc/inet_addr.cc
+++ b/libiqxmlrpc/inet_addr.cc
@@ -113,6 +113,7 @@ Inet_addr::Impl::init_sockaddr() const
   struct hostent* hent = nullptr;
   {
     std::lock_guard<std::mutex> lock(dns_mutex());
+    // NOLINTNEXTLINE(concurrency-mt-unsafe) - protected by dns_mutex()
     IQXMLRPC_GETHOSTBYNAME(host.c_str());
     sa->sin_family = PF_INET;
     sa->sin_port = htons(port);


### PR DESCRIPTION
## Summary
- Add `NOLINTNEXTLINE(concurrency-mt-unsafe)` to suppress clang-tidy warning
- The `gethostbyname` call is already protected by `dns_mutex()`

## Context
The `concurrency-mt-unsafe` check flags functions that use internal static buffers. However, our code already:
1. Uses `gethostbyname_r` (thread-safe) on Linux/Solaris
2. Protects the fallback `gethostbyname` with a mutex on macOS/Windows
3. Copies data while holding the lock

The warning is a false positive in this case.

## Test plan
- [x] `make check` passes
- [x] No new warnings introduced