### PR TITLE
Replace inet_ntoa with thread-safe inet_ntop

### DIFF
--- a/tests/test_inet_addr.cc
+++ b/tests/test_inet_addr.cc
@@ -140,7 +140,10 @@ BOOST_AUTO_TEST_CASE(get_sockaddr_from_existing_sockaddr)
     const struct sockaddr_in* sa = addr.get_sockaddr();
     BOOST_REQUIRE(sa != nullptr);
     BOOST_CHECK_EQUAL(ntohs(sa->sin_port), 5000);
-    BOOST_CHECK_EQUAL(inet_ntoa(sa->sin_addr), std::string("10.20.30.40"));
+    char buf[INET_ADDRSTRLEN];
+    const char* result = inet_ntop(AF_INET, &sa->sin_addr, buf, sizeof(buf));
+    BOOST_REQUIRE(result != nullptr);
+    BOOST_CHECK_EQUAL(std::string(buf), "10.20.30.40");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- Replace `inet_ntoa()` with thread-safe `inet_ntop()` in `inet_addr.cc`
- `inet_ntoa` uses a static buffer, making it not thread-safe (CWE-362)
- `inet_ntop` uses a caller-provided buffer, eliminating the race condition
- Added `NOLINTNEXTLINE(bugprone-unchecked-optional-access)` for false positive
  (clang-tidy doesn't recognize `has_value()` check before access)
- Updated test to use `inet_ntop` for consistency

## Changes
| File | Change |
|------|--------|
| `libiqxmlrpc/inet_addr.cc` | Replace `inet_ntoa` with `inet_ntop`, add suppression |
| `tests/test_inet_addr.cc` | Update test to use `inet_ntop` |

## Fixes
- clang-tidy `concurrency-mt-unsafe` warning for `inet_ntoa` at line 103
- clang-tidy `bugprone-unchecked-optional-access` false positive at line 156

## Test plan
- [x] `make check` passes (all 16 tests)
- [x] Quality agents pass (code-review, security, simplifier)
- [ ] CI passes