### PR TITLE
Suppress false positive bugprone-branch-clone warnings

### DIFF
--- a/libiqxmlrpc/http.cc
+++ b/libiqxmlrpc/http.cc
@@ -567,6 +567,7 @@ Response_header::Response_header( int c, const std::string& p ):
       std::lock_guard<std::mutex> lock(s_config_mutex);
       server_header = s_custom_server_header;
     }
+    // NOLINTNEXTLINE(bugprone-branch-clone) - false positive: different string arguments
     if (server_header.empty()) {
       set_option(names::server, PACKAGE " " VERSION);
     } else {
@@ -696,6 +697,7 @@ bool Packet_reader::read_header( const std::string& s )
 
   // SECURITY: Check header size limit to prevent header-based DoS attacks
   if (header_max_sz) {
+    // NOLINTNEXTLINE(bugprone-branch-clone) - false positive: different size conditions
     if (sep_pos == std::string::npos) {
       // No separator found yet - if accumulated data exceeds limit, reject
       // (headers alone shouldn't be this big)


### PR DESCRIPTION
## Summary
- Add NOLINTNEXTLINE comments to suppress two false positive `bugprone-branch-clone` warnings from clang-tidy

## Details

Both warnings are false positives where clang-tidy incorrectly identifies branches as "clones":

### 1. Server Header Selection (line 570)
```cpp
if (server_header.empty()) {
  set_option(names::server, PACKAGE " " VERSION);  // compile-time constant
} else {
  set_option(names::server, server_header);        // runtime variable
}
```
Clang-tidy only sees identical function calls, but the arguments are fundamentally different - one is a compile-time string constant, the other is a user-configurable runtime string.

### 2. Header Size DoS Protection (line 700)
```cpp
if (sep_pos == std::string::npos) {
  if (header_cache.length() > header_max_sz) { throw Request_too_large(); }
} else {
  if (sep_pos > header_max_sz) { throw Request_too_large(); }
}
```
Clang-tidy sees identical `throw` statements, but the branches protect against two distinct attack vectors:
- Branch 1: Unbounded header accumulation before separator found
- Branch 2: Oversized headers after separator found

Both branches compare **different values** against the limit.

## Test plan
- [x] `make check` passes (all 16 tests)
- [x] Build succeeds with no warnings
- [x] Code review confirms suppressions are appropriate
- [x] Security review confirms no real issues hidden