### PR TITLE
Fail CI on clang-tidy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,17 +317,11 @@ jobs:
 
     - name: Run clang-tidy
       run: |
+        set -euo pipefail
         # Run clang-tidy on library sources only (not tests or fuzz targets)
         # Use -print0/-0 to handle filenames with spaces safely
         find libiqxmlrpc -name '*.cc' -print0 | \
-          xargs -0 clang-tidy -p build --warnings-as-errors='' 2>&1 | tee clang-tidy-output.txt
-
-        # Check for errors (not warnings)
-        if grep -E "error:" clang-tidy-output.txt; then
-          echo "::error::clang-tidy found errors"
-          exit 1
-        fi
-        echo "clang-tidy passed"
+          xargs -0 clang-tidy -p build --warnings-as-errors='*' 2>&1 | tee clang-tidy-output.txt
 
     - name: Upload clang-tidy output
       uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Summary
- treat clang-tidy warnings as errors in CI
- remove manual grep-based error detection

## Testing
- not run (CI only change)