### PR TITLE
Fix documentation and potential division-by-zero

### DIFF
--- a/libiqxmlrpc/ssl_lib.h
+++ b/libiqxmlrpc/ssl_lib.h
@@ -111,7 +111,7 @@ public:
   //! Enable hostname verification for client connections.
   /*! SECURITY: Verifies that server certificate matches the expected hostname.
       Checks both Common Name (CN) and Subject Alternative Names (SAN).
-      Requires OpenSSL 1.0.2+.
+      Requires OpenSSL 1.1.0+.
       \param enable Whether to enable hostname verification (default: true)
   */
   void set_hostname_verification(bool enable);

--- a/tests/test_resource_limits.h
+++ b/tests/test_resource_limits.h
@@ -3,7 +3,6 @@
 
 #include <algorithm>
 #include <cstdlib>
-#include <string>
 
 #if !defined(_WIN32)
 #include <sys/resource.h>
@@ -120,7 +119,7 @@ inline int tuned_thread_count(int requested, size_t per_thread_budget = 32) {
     return requested;
   }
   const size_t limit = get_fd_soft_limit();
-  if (limit == 0) {
+  if (limit == 0 || per_thread_budget == 0) {
     return requested;
   }
   const size_t max_threads = std::max<size_t>(1, limit / per_thread_budget);


### PR DESCRIPTION
## Summary
- Update ssl_lib.h hostname verification comment from "Requires OpenSSL 1.0.2+" to "Requires OpenSSL 1.1.0+" to match the actual minimum version after dropping legacy OpenSSL support
- Add division-by-zero guard in `tuned_thread_count()` for `per_thread_budget == 0` case
- Remove unused `<string>` header include in test_resource_limits.h

## Test plan
- [x] `make check` passes (16/16 tests)
- [x] No compiler warnings
- [x] Changes verified via code review