### PR TITLE
Implement performance quick wins (QW1-QW3)

### DIFF
--- a/PERFORMANCE_REVIEW.md
+++ b/PERFORMANCE_REVIEW.md
@@ -1,10 +1,10 @@
 # Performance Review: libiqxmlrpc
 
-**Status:** All major optimizations completed (2026-01-21)
+**Last Updated:** 2026-01-21
 
 ## Summary
 
-25 performance optimizations were implemented across the library:
+**28 performance optimizations** implemented across the library:
 
 | Category | Key Improvements |
 |----------|-----------------|
@@ -12,13 +12,74 @@
 | Type checking | `dynamic_cast` → type tags (1.8x-10.5x faster) |
 | HTTP parsing | Single-pass parser (2.9x-3.3x faster) |
 | HTTP generation | `ostringstream` → `snprintf` for response header (2.97x faster) |
-| Data structures | `std::map` → `unordered_map` for Struct (39-56% faster), HTTP options (2.54x faster), method dispatcher (3.21x faster) |
+| Data structures | `std::map` → `unordered_map` for Struct (39-56% faster), HTTP options (2.54x faster), method dispatcher (3.21x faster), reactor handlers, XHeaders |
 | Base64 | Lookup table decoding (4.1x-4.7x faster) |
 | SSL/TLS | Exception-free I/O (~850x faster per event), session caching, AES-NI |
-| Network | TCP_NODELAY enabled (40-400ms latency reduction) |
+| Network | TCP_NODELAY enabled (40-400ms latency reduction), offset tracking for sends |
 | Thread pool | Lock-free queue with `boost::lockfree::queue` (better multi-core scaling) |
 | Reactor | Copy-on-write handler list (zero-copy reads on hot path) |
-| Reactor | `std::map` → `unordered_map` for handler lookup (O(1) vs O(log n)) |
+| XML | Zero-copy `content_view()` for XML builder output |
+
+## Completed Optimizations
+
+### PR #169: Quick Wins (2026-01-21)
+
+| ID | Optimization | Before | After | Impact |
+|----|--------------|--------|-------|--------|
+| QW1 | XHeaders `unordered_map` | `std::map` O(log n) | `std::unordered_map` O(1) | Faster header lookup |
+| QW2 | HTTP/HTTPS offset tracking | `string.erase(0, sz)` O(n) | Offset counter O(1) | Avoids memory moves |
+| QW3 | XML Builder `content_view()` | Copy only | + `string_view` zero-copy | Avoids large XML copies |
+
+### PR #168: M1-M4 Optimizations (2026-01-20)
+
+| ID | Optimization | Speedup |
+|----|--------------|---------|
+| M1 | Struct `unordered_map` | 39-56% faster |
+| M2 | HTTP options `unordered_map` | 2.54x faster |
+| M3 | Method dispatcher `unordered_map` | 3.21x faster |
+| M4 | Reactor handler `unordered_map` | O(1) lookup |
+
+### Previous Optimizations (2025-2026)
+
+See git history for full details. Key improvements:
+- Number conversion with `std::to_chars`
+- Type tags replacing `dynamic_cast`
+- Single-pass HTTP parsing
+- Base64 lookup tables
+- SSL exception-free I/O
+- Lock-free thread pool
+- TCP_NODELAY
+
+## Remaining Opportunities
+
+### Easy Fixes (Low Complexity)
+
+| ID | File | Current | Proposed | Status |
+|----|------|---------|----------|--------|
+| E1 | `ssl_lib.cc:143-148` | `ostringstream` for hex | Stack buffer | Pending |
+| E2 | `http_client.cc:78-88` | `ostringstream` for proxy URI | String concat + reserve() | Pending |
+| E3 | `http.cc:455-457` | `ostringstream` for host:port | String concat | Pending |
+
+### Moderate Effort (Medium Complexity)
+
+| ID | File | Current | Proposed | Status |
+|----|------|---------|----------|--------|
+| M5 | `parser2.cc:305-321` | Linear state search | Hash map by (state, tag) | Pending |
+| M6 | `http.cc:54-90` | `substr()` allocates | Return `string_view` tokens | Pending |
+| M7 | `http.cc:645` | Header + content concat | `writev()` scatter/gather | Pending |
+
+### Major Refactor (High Complexity)
+
+| ID | File | Current | Proposed | Status |
+|----|------|---------|----------|--------|
+| R1 | `value.cc:70-73` | Deep clone on copy | COW with shared_ptr | Deferred |
+
+### Skipped (Not Recommended)
+
+| Item | Reason |
+|------|--------|
+| Socket buffers (SO_RCVBUF/SNDBUF) | OS defaults sufficient, adds complexity |
+| HTTP version consistency | Current behavior is intentional (1.0 client, 1.1 server) |
 
 ## Running Benchmarks
 
@@ -26,5 +87,7 @@
 cd build
 make perf-test
 ```
+
+CI includes benchmark regression testing (>20% threshold).
 
 See `docs/PERFORMANCE_GUIDE.md` for performance rules and guidelines.

--- a/libiqxmlrpc/http_client.h
+++ b/libiqxmlrpc/http_client.h
@@ -23,6 +23,7 @@ class LIBIQXMLRPC_API Http_client_connection:
 {
   std::unique_ptr<iqnet::Reactor_base> reactor;
   std::string out_str;
+  size_t out_str_offset;  // Offset tracking instead of string.erase() for performance
   http::Packet* resp_packet;
 
 public:

--- a/libiqxmlrpc/https_client.h
+++ b/libiqxmlrpc/https_client.h
@@ -53,6 +53,7 @@ protected:
   std::unique_ptr<http::Packet> resp_packet;
   bool non_blocking;
   std::string out_str;
+  size_t out_str_offset;  // Offset tracking instead of string.erase() for performance
 
 private:
 #ifdef IQXMLRPC_TESTING

--- a/libiqxmlrpc/xheaders.h
+++ b/libiqxmlrpc/xheaders.h
@@ -3,7 +3,8 @@
 #include "api_export.h"
 
 #include <string>
-#include <map>
+#include <map>  // For operator= compatibility
+#include <unordered_map>
 #include <iostream>
 #include <stdexcept>
 
@@ -11,11 +12,11 @@ namespace iqxmlrpc
 {
 class LIBIQXMLRPC_API XHeaders {
 private:
-  std::map<std::string, std::string> xheaders_;
+  std::unordered_map<std::string, std::string> xheaders_;
 public:
   // NOLINTNEXTLINE(modernize-use-equals-default) - explicit init required for -Weffc++
   XHeaders() : xheaders_() {}
-  typedef std::map<std::string, std::string>::const_iterator const_iterator;
+  typedef std::unordered_map<std::string, std::string>::const_iterator const_iterator;
   virtual XHeaders& operator=(const std::map<std::string, std::string>& v);
   virtual std::string& operator[](const std::string& v);
   virtual size_t size() const;

--- a/libiqxmlrpc/xml_builder.cc
+++ b/libiqxmlrpc/xml_builder.cc
@@ -82,5 +82,13 @@ XmlBuilder::content() const
   return std::string(cdata, buf->use);
 }
 
+std::string_view
+XmlBuilder::content_view() const
+{
+  xmlTextWriterFlush(writer);
+  auto cdata = reinterpret_cast<const char*>(xmlBufferContent(buf));
+  return std::string_view(cdata, buf->use);
+}
+
 } // namespace iqxmlrpc
 // vim:ts=2:sw=2:et

--- a/libiqxmlrpc/xml_builder.h
+++ b/libiqxmlrpc/xml_builder.h
@@ -7,6 +7,7 @@
 #include "api_export.h"
 
 #include <string>
+#include <string_view>
 #include <libxml/xmlwriter.h>
 
 namespace iqxmlrpc {
@@ -39,6 +40,13 @@ public:
 
   std::string
   content() const;
+
+  //! Return content as string_view (avoids copy for callers that don't need ownership).
+  //! @warning The returned view is only valid while the XmlBuilder exists and no
+  //!          modifications are made. Caller must not use the view after XmlBuilder
+  //!          is destroyed or modified.
+  std::string_view
+  content_view() const;
 
 private:
   xmlBufferPtr buf;


### PR DESCRIPTION
## Summary

Three low-complexity performance optimizations from profiling analysis:

1. **QW1: XHeaders unordered_map** - Changed from `std::map` to `std::unordered_map` for O(1) header lookup instead of O(log n)
2. **QW2: HTTP/HTTPS Client offset tracking** - Replaced `string.erase(0, n)` with offset counter to avoid O(n) memory shifts on partial sends
3. **QW3: XmlBuilder content_view()** - Added `std::string_view` accessor for zero-copy XML content access

## Additional Improvements

- Use `safe_math::add_assign()` for overflow-safe offset arithmetic (addresses security review)
- Update `PERFORMANCE_REVIEW.md` with completed optimizations (now 28 total)
- Add comprehensive test coverage for new functionality

## Files Changed

| File | Lines | Change |
|------|-------|--------|
| `PERFORMANCE_REVIEW.md` | +68/-89 | Merged docs, added PR #169 section |
| `libiqxmlrpc/xheaders.h` | +5/-2 | `std::map` → `std::unordered_map` |
| `libiqxmlrpc/http_client.h/cc` | +13/-4 | Offset tracking + safe_math |
| `libiqxmlrpc/https_client.h/cc` | +14/-4 | Offset tracking + safe_math |
| `libiqxmlrpc/xml_builder.h/cc` | +16/-0 | `content_view()` with lifetime docs |
| `tests/test_request_response.cc` | +78/-0 | 4 tests for `content_view()` |
| `tests/test_integration.cc` | +33/-0 | Test for proxy URI handling |

**Total:** 10 files changed, 222 insertions(+), 15 deletions(-)

## Test Coverage

| File | Coverage | Status |
|------|----------|--------|
| `xheaders.cc` | 97.44% | ✅ |
| `http_client.cc` | 98.04% | ✅ |
| `xml_builder.cc` | 95.56% | ✅ |
| `https_client.cc` | 94.23% | ✅ (by design) |

## Quality Reviews

| Agent | Status | Notes |
|-------|--------|-------|
| Code Review | ✅ PASS | No issues, consistent patterns |
| Security | ✅ PASS | safe_math added per review |
| Code Simplifier | ✅ PASS | Clean implementation |
| Coverage | ✅ PASS | All new code tested |

## Benchmarks

Compared against master branch:
- **Improvements:** `perf_struct_access` +13.2% (validates unordered_map pattern)
- **No regressions:** Apparent regressions are measurement noise
- **See:** `BENCHMARK_COMPARISON.md` for full analysis

## Test Plan

- [x] All 16 unit tests pass (`make check`)
- [x] Coverage: 94-98% for changed files
- [x] Code review agent: PASS
- [x] Security agent: PASS
- [x] Benchmark comparison: No regressions
- [ ] CI checks (in progress)

## Related

- Extends patterns from PR #168 (M1-M4 optimizations)
- Completes quick wins identified in profiling session