### PR TITLE
Exclude tests from Coverity Scan analysis

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -78,7 +78,8 @@ jobs:
       run: |
         set -euo pipefail
         mkdir build && cd build
-        cmake -Dbuild_tests=ON \
+        # Disable tests - Coverity should only analyze library code, not test code
+        cmake -Dbuild_tests=OFF \
           -DCMAKE_CXX_FLAGS="-DBOOST_TIMER_ENABLE_DEPRECATED -Wall -Wextra" \
           ..
 


### PR DESCRIPTION
## Summary
Disable test compilation during Coverity scans by changing `build_tests=ON` to `build_tests=OFF`.

## Why
- **Focus analysis**: Coverity should analyze library code, not test code
- **Reduce false positives**: Test code often has patterns that trigger warnings (intentional error testing, etc.)
- **Smaller submissions**: Coverity free tier has submission size limits

## Changes
- `.github/workflows/coverity.yml`: Changed `-Dbuild_tests=ON` to `-Dbuild_tests=OFF`

## Test plan
- [x] Change is configuration-only, no code impact
- [x] Next Coverity scan will exclude tests directory