### PR TITLE
Fix socket resource leak in Reactor_interrupter

### DIFF
--- a/libiqxmlrpc/reactor_interrupter.cc
+++ b/libiqxmlrpc/reactor_interrupter.cc
@@ -46,7 +46,10 @@ public:
   Impl& operator=(const Impl&) = delete;
 
   explicit Impl(Reactor_base* reactor);
-  ~Impl() = default;
+  ~Impl() {
+    client_.shutdown();
+    client_.close();
+  }
 
   void make_interrupt();
 
@@ -69,6 +72,7 @@ Reactor_interrupter::Impl::Impl(Reactor_base* reactor):
   Inet_addr srv_addr(srv.get_addr());
   client_.connect( Inet_addr("127.0.0.1", srv_addr.get_port()) );
   Socket srv_conn(srv.accept());
+  srv.close();  // Close listening socket - no longer needed after accept()
 
   server_ = std::make_unique<Interrupter_connection>(reactor, srv_conn);
 }


### PR DESCRIPTION
## Summary
- Fix Coverity CID 641369 (Resource leak in object) in `reactor_interrupter.cc`
- Add destructor to close client socket using `shutdown()` + `close()` pattern
- Close listening socket immediately after `accept()` since it's no longer needed

## Why this matters
Each leaked socket consumes a file descriptor. Long-running servers would gradually exhaust the FD limit and fail to accept new connections.

## Test plan
- [x] `make check` passes (17/17 tests)
- [x] Code review agent passed
- [x] Security agent passed
- [x] Code simplifier agent passed
- [x] Coverage agent passed