### PR TITLE
Version 0.14.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(Libiqxmlrpc)
-set(Libiqxmlrpc_VERSION 0.14.0)
+set(Libiqxmlrpc_VERSION 0.14.1)
 
 # Require C++17 standard for entire project
 set(CMAKE_CXX_STANDARD 17)

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,14 @@
 Look into ChangeLog file for full list of changes.
 
+0.14.0 - 0.14.1
+  Bug Fixes:
+    * Fix socket resource leak in Reactor_interrupter (Coverity CID 641369)
+    * Refactor lock scope in reactor for clarity (Coverity CID 641343)
+
+  Test Coverage:
+    * Add SSL connection coverage tests (ssl_connection.cc, ssl_lib.cc)
+    * Add HTTP/HTTPS server error handling coverage tests
+
 0.13.8 - 0.14.0
   This release is BINARY INCOMPATIBLE with previous versions!
 


### PR DESCRIPTION
## Summary
- Bump version from 0.14.0 to 0.14.1
- Add NEWS entries for changes since 0.14.0 release

## Changes Since 0.14.0

### Bug Fixes
- Fix socket resource leak in Reactor_interrupter (Coverity CID 641369) - PR #192
- Refactor lock scope in reactor for clarity (Coverity CID 641343) - PR #193

### Test Coverage
- Add SSL connection coverage tests (ssl_connection.cc, ssl_lib.cc) - PR #189
- Add HTTP/HTTPS server error handling coverage tests - PR #190

## Test plan
- [x] Build passes (`make -j4`)
- [x] All tests pass (`make check`)
- [x] Version correctly set to 0.14.1

## Post-merge
After merging this PR:
1. Create and push tag: `git tag 0.14.1 && git push origin 0.14.1`