### PR TITLE
Suppress Coverity CID 641369 false positive in Socket destructor

### DIFF
--- a/libiqxmlrpc/socket.h
+++ b/libiqxmlrpc/socket.h
@@ -28,6 +28,10 @@ public:
   //! Create object from existing socket handler.
   Socket( Handler, const Inet_addr& );
   //! Destructor. Does not close actual socket.
+  //! Socket uses explicit close() for resource management to support
+  //! value semantics and ownership transfer (e.g., from accept()).
+  // coverity[autosar_cpp14_a15_5_1_violation : FALSE_POSITIVE]
+  // coverity[CTOR_DTOR_LEAK : FALSE_POSITIVE]
   virtual ~Socket() = default;
 
   Handler get_handler() const { return sock; }


### PR DESCRIPTION
## Summary
- Add Coverity suppression annotations to mark CID 641369 (CTOR_DTOR_LEAK) as a false positive
- Add documentation explaining the intentional design choice

## Analysis

Coverity flagged that `Socket::Socket()` allocates a socket FD but `~Socket()` doesn't close it. However, this is **intentional design**:

1. **Documented behavior**: The destructor comment explicitly states "Does not close actual socket"
2. **Value semantics**: Socket objects are passed by value (e.g., `accept()` returns `Socket`)
3. **Explicit cleanup**: All owners properly call `close()` in their destructors:
   - `Connection::~Connection()` - calls `sock.close()`
   - `Acceptor::~Acceptor()` - calls `sock.close()`
   - `Reactor_interrupter::Impl::~Impl()` - calls `client_.close()`

## Test plan
- [x] Build passes (`make -j4`)
- [x] All tests pass (`make check`)
- [x] Code review agent: Approved
- [x] Security agent: PASS
- [x] Code simplifier: No changes needed