### PR TITLE
Fix NEWS changelog and add SPDX license identifier

### DIFF
--- a/License
+++ b/License
@@ -1,3 +1,7 @@
+BSD 2-Clause License
+
+SPDX-License-Identifier: BSD-2-Clause
+
 Copyright 2011 by Anton Dedov <adedov@gmail.com>
 Copyright 2019-2026 by Yaroslav Gorbunov <ygorbunov@gmail.com>
 


### PR DESCRIPTION
## Summary
- Fix NEWS to accurately reflect 0.14.0 vs 0.14.1 changes (moved misattributed items to correct version sections)
- Add BSD-2-Clause license identifier header for machine-readability and automated license detection (SPDX format)

## Test plan
- [x] Documentation-only changes, no code affected
- [x] NEWS accurately reflects version history
- [x] LICENSE header follows SPDX specification