### PR TITLE
Fix null pointer dereference in ssl::exception constructors

### DIFF
--- a/libiqxmlrpc/ssl_lib.cc
+++ b/libiqxmlrpc/ssl_lib.cc
@@ -346,8 +346,13 @@ Ctx::prepare_sni(SSL* ssl)
 // ----------------------------------------------------------------------------
 exception::exception() noexcept:
   ssl_err( ERR_get_error() ),
-  msg( ERR_reason_error_string(ssl_err) )
+  msg()
 {
+  // SECURITY: ERR_reason_error_string() returns nullptr when no error is queued
+  // (ssl_err == 0). Constructing std::string from nullptr is undefined behavior
+  // and causes a crash. Handle this case by providing a fallback message.
+  const char* reason = ERR_reason_error_string(ssl_err);
+  msg = reason ? reason : "unknown SSL error";
   msg.insert(0, "SSL: ");
 }
 


### PR DESCRIPTION
## Summary
- `ERR_reason_error_string()` returns `nullptr` when no SSL error is queued (`ssl_err == 0`)
- Constructing `std::string` from `nullptr` is undefined behavior and causes a crash
- Now checks for `nullptr` and provides fallback message "unknown SSL error"

## Security Impact
- **CWE-476**: NULL Pointer Dereference
- Crash when `ssl::exception()` is constructed with empty OpenSSL error queue
- Now gracefully handles the edge case with a meaningful error message

## Test Plan
- [x] Added tests for all three exception constructors
- [x] Tests verify no crash with empty error queue
- [x] Tests verify proper fallback message
- [x] `make check` passes
- [x] Reviewed by code-review and security agents