### PR TITLE
Add perf_ssl_result_return_code to relaxed benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -41,8 +41,9 @@ env:
   # Very high variance benchmarks (tier 2)
   # perf_string_to_int_new: extreme variance on CI (~70%)
   # Sub-nanosecond benchmarks: 1 clock cycle of jitter causes 30-100% swings
+  # perf_ssl_result_return_code: ~0.3ns, SSL result code check
   RELAXED_THRESHOLD_2: '70'
-  RELAXED_BENCHMARKS_2: 'perf_string_to_int_new,perf_atomic_bool_write,perf_type_check_int_false,perf_type_check_int_true,perf_type_check_string_true'
+  RELAXED_BENCHMARKS_2: 'perf_string_to_int_new,perf_atomic_bool_write,perf_type_check_int_false,perf_type_check_int_true,perf_type_check_string_true,perf_ssl_result_return_code'
 
 jobs:
   benchmark:


### PR DESCRIPTION
## Summary
- Add `perf_ssl_result_return_code` benchmark to tier 2 relaxed list (70% threshold)

## Rationale
This sub-nanosecond benchmark (~0.3ns) is highly sensitive to timing jitter. Just 1-2 CPU cycles of variance can cause 20%+ reported regressions.

## Context
During PR #205 (reactor null handler fix), this benchmark showed an 18.2% regression (0.33ns → 0.39ns) which was clearly a false positive - the change only added one null pointer check in completely unrelated code.

## Test plan
- [x] Benchmark workflow should pass with this change
- [x] No functional changes to library code