### PR TITLE
perf: Use xmlTextReaderConst* to eliminate xmlStrdup per parse step

### DIFF
--- a/docs/plans/2026-02-05-perf-optimizations-design.md
+++ b/docs/plans/2026-02-05-perf-optimizations-design.md
@@ -1,0 +1,126 @@
+# Performance Optimizations Design (Without Replacing libxml2)
+
+Date: 2026-02-05
+Status: Planned
+
+## Context
+
+Profiling shows 77% of CPU in XML parsing (libxml2) and 23% in XML serialization.
+These optimizations target code *around* libxml2 and how we *use* libxml2 APIs.
+
+---
+
+## A. Eliminate xmlStrdup in Parser (HIGH PRIORITY)
+
+**File:** `libiqxmlrpc/parser2.cc`
+**Profile evidence:** 344 samples in `xmlStrdup` within `read_data()`
+
+**Problem:** `xmlTextReaderName()` and `xmlTextReaderValue()` call `xmlStrdup()` internally,
+allocating a copy of the string. We then copy it into `std::string` and free the xmlChar*.
+This means every parse step does: malloc (xmlStrdup) -> memcpy (std::string ctor) -> free (xmlFree).
+
+**Solution:** Use `xmlTextReaderConstName()` and `xmlTextReaderConstValue()` which return
+pointers to libxml2's internal buffers without allocation. We still copy into std::string,
+but skip the xmlStrdup + xmlFree cycle.
+
+**Risk:** Low. `xmlTextReaderConstName()` returns a dictionary-interned string valid
+for the reader's lifetime. `xmlTextReaderConstValue()` returns a pointer valid until
+the next `xmlTextReaderRead()` call. Both are safe since we copy into std::string
+immediately.
+
+**Expected impact:** 10-20% reduction in parsing memory pressure, measurable RPS improvement.
+
+---
+
+## B. Cache HTTP Date String (HIGH PRIORITY)
+
+**File:** `libiqxmlrpc/http.cc`, `Response_header::current_date()`
+
+**Problem:** Every response calls `std::time()` + `gmtime_r()` + `strftime()` to format
+the HTTP Date header. Under 10K RPS, that's 10K system calls per second.
+
+**Solution:** Cache the formatted date string. Update once per second using atomic
+compare-exchange on the timestamp. Use `std::atomic<time_t>` for the last-update time
+and a thread-safe cached string.
+
+**Risk:** Low. HTTP date only needs 1-second precision per RFC 7231.
+
+**Expected impact:** Eliminates 99%+ of time/strftime syscalls.
+
+---
+
+## C. Eliminate CSP Mutex Lock Per Response (HIGH PRIORITY)
+
+**File:** `libiqxmlrpc/http.cc`, `Response_header` constructor, lines ~596-608
+
+**Problem:** A `std::mutex` is acquired on every response to check if CSP policy is set.
+CSP policy is set once at startup and never changes during server lifetime.
+
+**Solution:** Use an `std::atomic<bool>` flag to check if CSP is enabled. Only acquire
+the mutex when the flag is true (which means CSP was configured). Since CSP is set
+once at startup, the flag check is sufficient for the common case.
+
+**Risk:** Very low. Read-after-write ordering is guaranteed by acquire/release semantics.
+
+**Expected impact:** Eliminates mutex contention on every response.
+
+---
+
+## D. Avoid HSTS String Formatting Per Response (MEDIUM PRIORITY)
+
+**File:** `libiqxmlrpc/http.cc`, `Response_header` constructor
+
+**Problem:** When HSTS is enabled, every response does:
+`"max-age=" + std::to_string(s_hsts_max_age.load(...))` — creating temporary strings.
+HSTS max-age is a constant set once at startup.
+
+**Solution:** Cache the full HSTS header value string when `enable_hsts()` is called.
+Use a `std::atomic<bool>` flag + cached string (same pattern as CSP fix).
+
+**Risk:** Very low.
+
+**Expected impact:** Eliminates 2 string temporaries per response when HSTS is enabled.
+
+---
+
+## E. Reuse XML Visitor in Serialization (LOW PRIORITY)
+
+**File:** `libiqxmlrpc/value_type_xml.cc`, `do_visit_struct()` and `do_visit_array()`
+
+**Problem:** A new `Value_type_to_xml` visitor is created for each struct/array traversal.
+The visitor is just 2 pointers (builder + server_mode), so construction is cheap,
+but it's unnecessary.
+
+**Solution:** Use `*this` instead of creating a new visitor:
+```cpp
+value->apply_visitor(*this);  // instead of: value->apply_visitor(vis);
+```
+
+**Risk:** Need to verify visitor has no mutable state that would conflict.
+
+**Expected impact:** Minimal. Eliminates one small allocation per container element.
+
+---
+
+## F. Response_header Fallback Path (LOW PRIORITY)
+
+**File:** `libiqxmlrpc/http.cc`, `Response_header::dump_head()`, line 639
+
+**Problem:** Fallback string concatenation creates 4+ temporary strings.
+
+**Solution:** Use larger snprintf buffer or std::string::reserve.
+
+**Risk:** Very low. Only affects error/edge cases.
+
+**Expected impact:** Negligible (fallback path is rarely hit).
+
+---
+
+## Implementation Order
+
+1. **A** — xmlTextReaderConst* (biggest measured impact, hot path)
+2. **B** — Date caching (simple, high-frequency syscall elimination)
+3. **C** — CSP mutex (simple, reduces contention)
+4. **D** — HSTS string caching (simple, follows same pattern as C)
+5. **E** — Visitor reuse (verify safety first)
+6. **F** — Fallback path (low priority)


### PR DESCRIPTION
## Summary

- Replace `xmlTextReaderName()` / `xmlTextReaderValue()` with zero-copy `xmlTextReaderConstName()` / `xmlTextReaderConstValue()`
- Eliminates one `xmlStrdup` (malloc) + `xmlFree` (free) per XML node during parsing
- Adds NULL guards on `xmlReaderForMemory()`, `xmlTextReaderConstName()`, `xmlTextReaderConstValue()`
- Checks `xmlTextReaderSetParserProp()` return to ensure XXE protection is active
- Distinguishes `is_text` vs `element_end` in `read_data()` to avoid masking reader errors

## Benchmark Results

### C++ Micro-Benchmarks (xml-parsing-benchmark-test)

Isolates parsing performance — the authoritative signal for this change.

| Benchmark | Before (ns/op) | After (ns/op) | Improvement |
|-----------|----------------|---------------|-------------|
| parse_request_simple | 3,443 | 3,173 | **-7.8%** |
| parse_request_10_params | 10,054 | 9,119 | **-9.3%** |
| parse_request_100_params | 70,256 | 60,637 | **-13.7%** |
| parse_response_array_100 | 57,205 | 50,116 | **-12.4%** |
| parse_response_array_1000 | 535,736 | 467,949 | **-12.7%** |
| roundtrip_array_100 | 84,226 | 78,296 | **-7.0%** |
| roundtrip_struct_50 | 92,581 | 86,238 | **-6.8%** |

Improvement scales with payload size (~8% for small, ~14% for large) because larger payloads have more XML nodes, each saving one malloc+free cycle.

### RPS End-to-End Benchmark (2 runs averaged)

Full HTTP stack including networking and threading. Parsing is ~50% of CPU time, so a ~10% parsing improvement dilutes to ~5% end-to-end — within the ±5% variance floor.

| Scenario | Clients | Master (avg RPS) | Branch (avg RPS) | Delta |
|----------|---------|----------------:|----------------:|-------|
| small_payload | 1 | 6,222 | 6,222 | 0% |
| small_payload | 4 | 11,881 | 11,745 | -1.1% |
| small_payload | 8 | 11,393 | 11,476 | +0.7% |
| small_payload | 16 | 11,178 | 11,499 | +2.9% |
| large_payload | 1 | 113.7 | 112.7 | -0.9% |
| large_payload | 4 | 264.3 | 264.1 | 0% |
| large_payload | 8 | 266.2 | 265.4 | -0.3% |
| large_payload | 16 | 265.5 | 266.6 | +0.4% |

RPS results confirm no regression. The parsing improvement is real but below the noise threshold of the end-to-end benchmark.

## Test plan

- [x] All 19 test targets pass (100%)
- [x] C++ micro-benchmarks show 8-14% parsing improvement
- [x] RPS benchmark shows no regression (within ±5% variance)
- [x] Code review agents passed (code-reviewer, silent-failure-hunter, comment-analyzer, test-analyzer, code-simplifier)
- [ ] CI passes