### PR TITLE
bench: Use realistic production payload for RPS benchmarks

### DIFF
--- a/scripts/rps_benchmark.py
+++ b/scripts/rps_benchmark.py
@@ -303,7 +303,14 @@ Examples:
         sys.exit(1)
 
     # Define payloads
-    small_payload = "x" * 100           # ~100 bytes
+    # Realistic smallest production payload: struct with auth + nested array
+    small_payload = {
+        "Username": "user",
+        "Password": "12345678",
+        "Server": "SERVER",
+        "Method": "Method_API",
+        "Params": [87654321],
+    }
     large_payload = "x" * (1024 * 1024)  # ~1MB
 
     # Determine request counts


### PR DESCRIPTION
## Summary

- Replace the synthetic `"x" * 100` small payload in `rps_benchmark.py` with a realistic production struct matching the smallest real-world XML-RPC request pattern
- The new payload is a 5-member struct with auth credentials, server, method name, and a params array

## Changes

| File | Change |
|------|--------|
| `scripts/rps_benchmark.py` | Replace `small_payload` with realistic struct |

## Context

The original scope (thread-local xmlTextReader pooling) was reverted due to unbounded `xmlDict` growth across requests on long-lived server threads. libxml2 provides no API to reset the interned dictionary without destroying the reader, making the optimization unsuitable for servers processing untrusted input.

## Test plan

- [x] RPS benchmark runs successfully with the new payload
- [ ] CI passes