### PR TITLE
chore: Add clang-format config and MCP server definitions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,101 @@
+---
+# Libiqxmlrpc code style
+# Matches existing codebase conventions:
+# - 2-space indentation
+# - Allman braces for function definitions, K&R for everything else
+# - Return type on its own line for top-level function definitions
+# - Constructor initializers: colon at end of line, one per line
+
+Language: Cpp
+Standard: c++17
+
+IndentWidth: 2
+TabWidth: 2
+UseTab: Never
+ColumnLimit: 100
+
+# Brace style: functions get Allman, everything else gets K&R (attached)
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass: false
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: false
+  BeforeLambdaBody: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+
+# Return type on its own line for top-level definitions (matches existing style)
+AlwaysBreakAfterReturnType: TopLevelDefinitions
+
+# Constructor initializer lists: break after colon, one initializer per line
+BreakConstructorInitializers: AfterColon
+SpaceBeforeCtorInitializerColon: false
+ConstructorInitializerIndentWidth: 2
+PackConstructorInitializers: Never
+
+# Indentation
+AccessModifierOffset: -2
+IndentCaseLabels: true
+NamespaceIndentation: None
+IndentPPDirectives: None
+
+# Alignment
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignOperands: true
+AlignTrailingComments: true
+
+# Line breaks
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AllowShortLambdasOnASingleLine: Inline
+BinPackArguments: true
+BinPackParameters: true
+
+# Spaces
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+
+# Includes — preserve existing grouping and order
+SortIncludes: false
+IncludeBlocks: Preserve
+
+# Pointer/reference alignment
+PointerAlignment: Left
+ReferenceAlignment: Left
+
+# Penalty tuning
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 0
+
+# Misc
+FixNamespaceComments: false
+MaxEmptyLinesToKeep: 2
+ReflowComments: true
+...

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,23 @@
+{
+  "mcpServers": {
+    "github": {
+      "type": "stdio",
+      "command": "gh",
+      "args": [
+        "extension",
+        "exec",
+        "github-mcp-server"
+      ],
+      "env": {}
+    },
+    "context7": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@upstash/context7-mcp@latest"
+      ],
+      "env": {}
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `.clang-format` configuration matching the existing codebase style
- Add `.mcp.json` with GitHub and context7 MCP servers for Claude Code integration

## .clang-format Details
Captures the project's existing formatting conventions:
- 2-space indentation, no tabs
- Allman braces for function definitions, K&R for everything else
- Return type on its own line for top-level definitions
- Constructor initializer lists: colon at end of line, one per line
- Preserves include order and namespace comments
- 100-column soft limit

## MCP Servers
- **GitHub** (`gh extension exec github-mcp-server`): Direct GitHub API access for PRs, issues, CI status
- **context7** (`@upstash/context7-mcp`): Live documentation lookup for libxml2, Boost, OpenSSL APIs

## Test plan
- [x] Verified clang-format output matches existing code style (tested on parser2.cc)
- [x] No existing source files are modified