### PR TITLE
fix: Prevent Pool_executor use-after-free during server shutdown

### DIFF
--- a/libiqxmlrpc/server.cc
+++ b/libiqxmlrpc/server.cc
@@ -95,6 +95,8 @@ Server::Server(
 
 Server::~Server()
 {
+  // Wait for in-flight pool executors to finish before destroying Server state.
+  impl->exec_factory->drain();
   delete impl;
 }
 

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -55,6 +55,9 @@ namespace port_offset {
   constexpr int ADD_THREADS = 3;
   constexpr int CAPACITY_1024 = 4;
   constexpr int DESTRUCTOR_DRAIN = 5;
+  constexpr int SHUTDOWN_INFLIGHT = 6;
+  constexpr int POOL_EXCEPTIONS = 7;
+  constexpr int DRAIN_TIMEOUT_EXERCISE = 8;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- **Fix CWE-416 (HIGH):** Pool threads could dereference a dangling `Server*` after `~Server()` destroyed the impl, causing undefined behavior during shutdown under load
- Add `drain()` mechanism to `Pool_executor_factory` that blocks `~Server()` until all in-flight pool executors complete
- Add `Drain_guard` RAII struct for exception-safe outstanding count tracking
- Add 3 new tests covering the drain mechanism, pool exception paths, and timeout warning behavior

## Problem

During server shutdown with a thread pool:
1. `Server::work()` exits → server thread joins
2. `~Server()` runs → `delete impl` (destroys reactor, interrupter)
3. Pool threads still running → `schedule_response()` → `server->schedule_response()` → **UAF**
4. `~Pool_executor()` → `interrupt_server()` → `server->interrupt()` → **UAF**

## Approach

**Two-part fix with minimal blast radius:**

1. **`~Server()` calls `drain()`** — waits for all in-flight pool executors to finish before destroying server state. Uses `outstanding_count` atomic with condvar notification.

2. **`~Pool_executor()` skips `interrupt_server()`** when the pool is destructing — defensive guard for edge cases where the server is already destroyed.

**Key design decisions:**
- Increment `outstanding_count` *before* queue push to prevent transient-zero race in `drain()`
- RAII `Drain_guard` ensures decrement even when `process_actual_execution()` throws
- Conditional condvar notification (only when count drops to zero) to minimize contention
- `drain()` blocks indefinitely, logging a warning every 30s (configurable via `set_drain_timeout()`) — prevents UAF even with slow methods

## Files Changed

| File | Change |
|------|--------|
| `libiqxmlrpc/executor.h` | Add `drain()` to base class; add tracking members + `set_drain_timeout()` |
| `libiqxmlrpc/executor.cc` | Implement `drain()`, `Drain_guard`, increment-before-push, destructor guards |
| `libiqxmlrpc/server.cc` | Call `drain()` in `~Server()` before `delete impl` |
| `tests/test_common.h` | Add port offsets for new tests |
| `tests/test_thread_safety.cc` | Add 3 new test cases |

## Test plan

- [ ] `make check` — all tests pass (including 3 new: `shutdown_with_inflight_work`, `pool_exception_handling`, `drain_timeout_exercise`)
- [ ] ASan build passes (detects UAF if drain mechanism broken)
- [ ] TSan build passes (detects data races on `outstanding_count` handshake)
- [ ] Valgrind clean
- [ ] Benchmark CI shows no regression (drain is off the hot path)