### PR TITLE
security: Fix TOCTOU race on SSL hostname verification (CWE-367)

### DIFF
--- a/libiqxmlrpc/ssl_lib.cc
+++ b/libiqxmlrpc/ssl_lib.cc
@@ -14,6 +14,7 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
+#include <atomic>
 #include <cerrno>
 #include <mutex>
 #include <cstdio>
@@ -173,7 +174,7 @@ struct Ctx::Impl {
   ConnectionVerifier* server_verifier;
   ConnectionVerifier* client_verifier;
   bool require_client_cert;
-  bool hostname_verification;  // SECURITY: Verify hostname against certificate
+  std::atomic<bool> hostname_verification;  // SECURITY: Verify hostname against certificate
   std::string expected_hostname;
 
   Impl():

--- a/tests/test_ssl_hostname.cc
+++ b/tests/test_ssl_hostname.cc
@@ -180,7 +180,7 @@ BOOST_AUTO_TEST_CASE(ctx_hostname_verification_enabled_roundtrip)
 }
 
 // Test 7: Blocking ssl_connect() calls prepare_for_ssl_connect() before handshake.
-// Covers the blocking code path (ssl_connection.cc:97) used by non-reactor clients.
+// Covers the blocking code path in ssl::Connection::ssl_connect() used by non-reactor clients.
 // The reactor path goes through reg_connect() instead; this exercises the alternative.
 BOOST_AUTO_TEST_CASE(blocking_ssl_connect_calls_prepare)
 {
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE(blocking_ssl_connect_calls_prepare)
 }
 
 // Test 8: Blocking ssl_accept() calls prepare_for_ssl_accept() before handshake.
-// Covers the blocking code path (ssl_connection.cc:64) used by non-reactor servers.
+// Covers the blocking code path in ssl::Connection::ssl_accept() used by non-reactor servers.
 BOOST_AUTO_TEST_CASE(blocking_ssl_accept_calls_prepare)
 {
   SslContextGuard ctx_guard(ssl::Ctx::client_only());


### PR DESCRIPTION
## Summary

- **Fixes CWE-367 (TOCTOU race):** Shared mutable `expected_hostname` on `ssl::Ctx` was read/written concurrently when multiple client threads connected to different hosts. Moved hostname storage to per-connection level (`ssl::Connection::expected_hostname_`), eliminating the shared mutable state entirely.
- **Propagation chain:** `Client_base::set_expected_hostname()` → `Connector` → `ssl::Connection::set_expected_hostname()` → applied atomically at `prepare_hostname_for_connect()` time via SNI + X509_VERIFY_PARAM.
- **Backward compatible:** Ctx-level `set_expected_hostname()` still works as fallback for single-host clients.
- **Review hardening:** Made `Ctx::Impl::hostname_verification` `std::atomic<bool>` for data-race freedom on concurrent reads.

## Files Changed (14 files, +661/-46)

| Layer | Files | Change |
|-------|-------|--------|
| Client API | `client.h`, `client.cc` | Per-client `expected_hostname_` storage + accessor |
| Client Connection | `client_conn.h` | Virtual `set_ssl_expected_hostname()` (no-op base) |
| HTTPS Client | `https_client.h`, `https_client.cc` | Override forwarding hostname to connector |
| Connector | `connector.h`, `connector.cc` | Store + propagate hostname to ssl::Connection |
| SSL Connection | `ssl_connection.h`, `ssl_connection.cc` | Per-connection hostname + `prepare_hostname_for_connect()` |
| SSL Context | `ssl_lib.h`, `ssl_lib.cc` | Ctx-level fallback API, `std::atomic<bool>` verification flag |
| Tests | `test_ssl_hostname.cc` (new), `test_integration_ssl.cc`, `CMakeLists.txt` | 8 unit tests + 5 integration tests + 1 concurrency test |

## Test plan

- [x] `make check` — all 20 tests pass locally
- [x] 8 new unit tests (`ssl_hostname_unit_tests`) verify SNI, X509_VERIFY_PARAM, fallback, and blocking paths
- [x] 5 new integration tests verify end-to-end hostname verification with real TLS handshakes
- [x] 1 concurrency stress test (`concurrent_hostname_isolation`) verifies per-connection isolation under parallel load
- [ ] CI: ASan/UBSan, TSan, Valgrind, CodeQL, cppcheck, clang-tidy