### PR TITLE
security: Add client-side TLS certificate verification (CWE-295)

### DIFF
--- a/libiqxmlrpc/ssl_lib.h
+++ b/libiqxmlrpc/ssl_lib.h
@@ -79,6 +79,13 @@ public:
   static Ctx* server_only( const std::string& cert_path, const std::string& key_path );
   static Ctx* client_only();
 
+  //! Create a client SSL context with certificate verification enabled.
+  //! Loads the system CA store and enables SSL_VERIFY_PEER.
+  //! Connections will fail if the server certificate is not trusted.
+  //! The returned context has no cert/key and is for client connections only.
+  //! \throws ssl::exception if system CA store cannot be loaded.
+  static Ctx* client_verified();
+
   ~Ctx();
 
   SSL_CTX* context();
@@ -108,6 +115,15 @@ public:
       \return true on success, false on failure
   */
   bool use_default_verify_paths();
+
+  //! Enable peer certificate verification for outgoing (client) connections.
+  //! \note Only affects client-side connections. Server-side uses verify_client().
+  //! \note When a custom ConnectionVerifier is also set via verify_server(),
+  //!       setting verify_peer is harmless but redundant.
+  void set_verify_peer(bool enable);
+
+  //! Check if peer certificate verification is enabled.
+  bool verify_peer_enabled() const;
 
   //! Enable hostname verification for client connections.
   /*! SECURITY: Verifies that server certificate matches the expected hostname.


### PR DESCRIPTION
## Summary

- Add `Ctx::client_verified()` factory — loads system CAs, enables `SSL_VERIFY_PEER`
- Add `Ctx::set_verify_peer(bool)` / `verify_peer_enabled()` API for explicit peer verification control
- Modify `prepare_verify()` to respect `verify_peer` flag on client-side connections
- `client_only()` behavior is **unchanged** — full backward compatibility

**Security context:** `Ctx::client_only()` creates SSL contexts that never validate server certificates (`SSL_VERIFY_NONE`), enabling trivial MITM interception. Even though `hostname_verification` defaults to `true`, OpenSSL silently ignores hostname checks when peer verification is disabled.

## Test plan

- [x] 7 unit tests in `ssl_verify_peer_unit_tests` suite covering: factory creation, default state, roundtrip toggle, SSL_VERIFY_PEER mode, SSL_VERIFY_NONE default, custom verifier interaction, server-side isolation
- [x] 2 integration tests: positive path (trusted CA + verify_peer succeeds) and negative path (untrusted cert rejected)
- [x] All 21 tests pass locally (`make check`)
- [x] Coverage confirmed: all new production code paths exercised