### PR TITLE
security: Fix parser integer truncation (CWE-197) and harden TLS tests

### DIFF
--- a/libiqxmlrpc/ssl_lib.h
+++ b/libiqxmlrpc/ssl_lib.h
@@ -83,6 +83,9 @@ public:
   //! Loads the system CA store and enables SSL_VERIFY_PEER.
   //! Connections will fail if the server certificate is not trusted.
   //! The returned context has no cert/key and is for client connections only.
+  //! \note For hostname verification (MITM protection), callers must also set
+  //!       the expected hostname via Client_base::set_expected_hostname() or
+  //!       ssl::Connection::set_expected_hostname() before connecting.
   //! \throws ssl::exception if system CA store cannot be loaded.
   static Ctx* client_verified();
 

--- a/tests/test_integration_ssl.cc
+++ b/tests/test_integration_ssl.cc
@@ -579,7 +579,7 @@ BOOST_FIXTURE_TEST_CASE(https_set_verify_peer_with_trusted_ca, HttpsIntegrationF
 
   // Enable peer verification and load the self-signed cert as trusted CA
   get_context()->set_verify_peer(true);
-  get_context()->load_verify_locations(temp_cert_path_);
+  BOOST_REQUIRE(get_context()->load_verify_locations(temp_cert_path_));
 
   start_server(220);
   auto client = create_client();

--- a/tests/test_ssl_hostname.cc
+++ b/tests/test_ssl_hostname.cc
@@ -227,7 +227,7 @@ BOOST_AUTO_TEST_CASE(client_verified_creates_verify_peer_context)
   SslContextGuard ctx_guard(ssl::Ctx::client_verified());
 
   BOOST_REQUIRE(ctx_guard.get() != nullptr);
-  BOOST_CHECK(ctx_guard->verify_peer_enabled());
+  BOOST_REQUIRE(ctx_guard->verify_peer_enabled());
 }
 
 // client_only() defaults verify_peer to false (backward compatibility).
@@ -235,7 +235,7 @@ BOOST_AUTO_TEST_CASE(client_only_verify_peer_defaults_false)
 {
   SslContextGuard ctx_guard(ssl::Ctx::client_only());
 
-  BOOST_CHECK(!ctx_guard->verify_peer_enabled());
+  BOOST_REQUIRE(!ctx_guard->verify_peer_enabled());
 }
 
 // set_verify_peer() roundtrip: toggle on, verify, toggle off, verify.
@@ -266,7 +266,7 @@ BOOST_AUTO_TEST_CASE(prepare_verify_sets_ssl_verify_peer)
   ctx_guard->prepare_verify(conn.ssl_handle(), false);
 
   int mode = SSL_get_verify_mode(conn.ssl_handle());
-  BOOST_CHECK(mode & SSL_VERIFY_PEER);
+  BOOST_REQUIRE(mode & SSL_VERIFY_PEER);
 }
 
 // With verify_peer=false (default), prepare_verify() sets SSL_VERIFY_NONE.
@@ -300,7 +300,7 @@ BOOST_AUTO_TEST_CASE(custom_verifier_takes_precedence_over_verify_peer)
 
   // Mode should be SSL_VERIFY_PEER regardless
   int mode = SSL_get_verify_mode(conn.ssl_handle());
-  BOOST_CHECK(mode & SSL_VERIFY_PEER);
+  BOOST_REQUIRE(mode & SSL_VERIFY_PEER);
 
   // The custom callback should be installed (not nullptr).
   auto cb = SSL_get_verify_callback(conn.ssl_handle());


### PR DESCRIPTION
## Summary

- **CWE-197 (Numeric Truncation Error):** Add `INT_MAX` bounds check in `Parser::Impl` constructor before `static_cast<int>(str.size())`. `xmlReaderForMemory` takes `int` for buffer size; a >2GB payload would silently truncate, causing libxml2 to parse only a fragment. This matches the guard pattern already used in `socket.cc` and `ssl_connection.cc`.
- **TLS test hardening (follow-up to #227):** Upgrade `BOOST_CHECK` to `BOOST_REQUIRE` for core security invariants in TLS verification tests, check `load_verify_locations()` return value, and add `\note` to `client_verified()` docstring about hostname verification.

### Files changed

| File | Change |
|------|--------|
| `libiqxmlrpc/parser2.cc` | Add `#include <limits>` and INT_MAX bounds check before `xmlReaderForMemory` call |
| `libiqxmlrpc/ssl_lib.h` | Add `\note` to `client_verified()` docstring about hostname verification requirement |
| `libiqxmlrpc/ssl_lib.cc` | No functional change (carried forward from rebase) |
| `tests/test_security_edge_cases.cc` | 2 tests for parser truncation: regression test + exception verification; fix stale comment (100,000 → 10,000,000) |
| `tests/test_ssl_hostname.cc` | Upgrade `BOOST_CHECK` → `BOOST_REQUIRE` for `verify_peer_enabled()` and `SSL_VERIFY_PEER` mode assertions |
| `tests/test_integration_ssl.cc` | Add `BOOST_REQUIRE` for `load_verify_locations()` return value in positive test |

## Test plan
- [x] `make check` passes (21 tests)
- [x] Parser regression test: normal XML still parses correctly after guard added
- [x] Parser exception test: `Parse_error` carries fault code -32700 and expected message
- [x] TLS unit tests use `BOOST_REQUIRE` for core invariants (fail-fast on security regressions)
- [x] TLS integration test checks `load_verify_locations()` return value