### PR TITLE
security: Add ConnectionGuard to prevent Pool_executor use-after-free (CWE-416)

### DIFF
--- a/libiqxmlrpc/executor.h
+++ b/libiqxmlrpc/executor.h
@@ -28,6 +28,8 @@ namespace iqxmlrpc {
 class Server;
 class Server_connection;
 class Response;
+class ConnectionGuard;
+using ConnectionGuardPtr = std::shared_ptr<ConnectionGuard>;
 
 class Serial_executor_factory;
 class Pool_executor_factory;
@@ -57,6 +59,7 @@ protected:
 private:
   Server* server;
   Server_connection* conn;
+  ConnectionGuardPtr conn_guard_;
 
 public:
   Executor( Method*, Server*, Server_connection* );
@@ -73,6 +76,7 @@ public:
 protected:
   void schedule_response( const Response& );
   void interrupt_server();
+  void set_connection_guard(ConnectionGuardPtr g) { conn_guard_ = std::move(g); }
 };
 
 

--- a/libiqxmlrpc/http_server.cc
+++ b/libiqxmlrpc/http_server.cc
@@ -79,6 +79,7 @@ void Http_server_connection::post_accept()
 
 void Http_server_connection::finish()
 {
+  invalidate_guard();
   server->unregister_connection(this);
   delete this;
 }

--- a/libiqxmlrpc/https_server.cc
+++ b/libiqxmlrpc/https_server.cc
@@ -70,6 +70,7 @@ inline void Https_server_connection::my_reg_recv()
 
 void Https_server_connection::finish()
 {
+  invalidate_guard();
   server->unregister_connection(this);
   delete this;
 }

--- a/libiqxmlrpc/server.cc
+++ b/libiqxmlrpc/server.cc
@@ -328,6 +328,17 @@ void Server::schedule_response(
   conn->schedule_response( packet );
 }
 
+void Server::schedule_response(
+  const Response& resp, const ConnectionGuardPtr& guard, Executor* exec )
+{
+  std::unique_ptr<Executor> executor_to_delete(exec);
+  std::string resp_str = dump_response(resp);
+  auto *packet = new http::Packet(new http::Response_header(), std::move(resp_str));
+  if (!guard->try_schedule_response(packet)) {
+    log_err_msg("Response delivery failed (connection may have been closed)");
+  }
+}
+
 void Server::set_firewall( iqnet::Firewall_base* _firewall )
 {
   impl->firewall = _firewall;

--- a/libiqxmlrpc/server.h
+++ b/libiqxmlrpc/server.h
@@ -107,6 +107,7 @@ public:
 
   void schedule_execute( http::Packet*, Server_connection* );
   void schedule_response( const Response&, Server_connection*, Executor* );
+  void schedule_response( const Response&, const ConnectionGuardPtr&, Executor* );
 
   void log_err_msg( const std::string& );
 

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -58,6 +58,7 @@ namespace port_offset {
   constexpr int SHUTDOWN_INFLIGHT = 6;
   constexpr int POOL_EXCEPTIONS = 7;
   constexpr int DRAIN_TIMEOUT_EXERCISE = 8;
+  constexpr int GUARD_REJECTION = 9;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Introduce `ConnectionGuard` — a mutex-protected proxy that prevents use-after-free when `finish()` deletes a connection while a pool thread is still delivering a response
- Guard is owned via `shared_ptr` so it outlives the connection; `invalidate()` nulls the raw pointer under mutex before `delete this`
- `try_schedule_response()` atomically checks liveness and delivers or safely drops the packet
- Exception-safe: catches `std::exception` and unknown types separately, logging to stderr (consistent with `~Pool_executor` pattern) to prevent pool thread termination
- Defense-in-depth: `~Server_connection` auto-invalidates if subclass `finish()` forgets

### Files changed (10)
| File | Change |
|------|--------|
| `server_conn.h` | `ConnectionGuard` class, `ConnectionGuardPtr` typedef, `connection_guard()` accessor, `invalidate_guard()` |
| `server_conn.cc` | Guard implementation (mutex-protected invalidate/try_schedule), constructor init, defense-in-depth destructor, exception-safe delivery |
| `executor.h` | Forward decl + `conn_guard_` member + `set_connection_guard()` setter |
| `executor.cc` | `Pool_executor` captures guard; `Executor::schedule_response()` routes through guard when available |
| `server.h/cc` | New `schedule_response(Response, ConnectionGuardPtr, Executor*)` overload with hedged log message |
| `http_server.cc` | `invalidate_guard()` before `delete this` in `finish()` |
| `https_server.cc` | Same pattern for HTTPS connections |
| `test_common.h` | `GUARD_REJECTION` port offset |
| `test_thread_safety.cc` | 7 new tests: lifecycle, drop, destructor, concurrent stress (100 trials x 5 threads), guard rejection integration, std::exception handling, catch(...) fallback |

## Test plan
- [x] `make check` — all 21 tests pass locally
- [x] 100% patch coverage on all PR-introduced lines (verified locally with gcov)
- [x] CI: ASan/UBSan (memory safety)
- [x] CI: TSan (data race detection on the new mutex paths)
- [x] CI: Valgrind (leak detection for dropped packets)
- [x] CI: Benchmark (no regression — guard is off the hot serial path)