### PR TITLE
security: Reject Transfer-Encoding header (CWE-444)

### DIFF
--- a/libiqxmlrpc/http_server.cc
+++ b/libiqxmlrpc/http_server.cc
@@ -106,9 +106,8 @@ void Http_server_connection::handle_input( bool& terminate )
   }
   catch( const http::Error_response& e )
   {
-    // Close connection after sending HTTP error response
+    server->log_err_msg( std::string("Http: ") + e.what() );
     keep_alive = false;
-    // Packet payload is sufficient here; slicing is intentional.
     schedule_response( new http::Packet(e) );  // NOLINT(cppcoreguidelines-slicing)
   }
 }

--- a/libiqxmlrpc/https_server.cc
+++ b/libiqxmlrpc/https_server.cc
@@ -113,9 +113,8 @@ void Https_server_connection::recv_succeed( bool&, size_t, size_t real_len )
   }
   catch( const http::Error_response& e )
   {
-    // Close connection after sending HTTP error response
+    server->log_err_msg( std::string("Https: ") + e.what() );
     keep_alive = false;
-    // Packet payload is sufficient here; slicing is intentional.
     schedule_response( new http::Packet(e) );  // NOLINT(cppcoreguidelines-slicing)
   }
 }


### PR DESCRIPTION
## Summary
- Rejects any HTTP request/response containing a `Transfer-Encoding` header to prevent CL.TE request smuggling
- Registered as `HTTP_CHECK_WEAK` validator so it fires at all verification levels
- Since libiqxmlrpc only supports Content-Length framing, outright rejection is the simplest and safest approach

## Test plan
- [x] 10 new test cases in `test_http.cc` covering:
  - chunked, identity, case-insensitive header matching
  - CL+TE combination attack vector
  - TE-only without Content-Length
  - Whitespace bypass attempts
  - Strict verification level
  - Both request and response `Packet_reader` paths
- [x] `make check` passes (21/21 tests)