### PR TITLE
security: Sanitize error messages in client-facing XML-RPC faults (CWE-209)

### DIFF
--- a/libiqxmlrpc/executor.h
+++ b/libiqxmlrpc/executor.h
@@ -76,6 +76,7 @@ public:
 protected:
   void schedule_response( const Response& );
   void interrupt_server();
+  void log_err_msg( const std::string& msg );
   void set_connection_guard(ConnectionGuardPtr g) { conn_guard_ = std::move(g); }
 };
 

--- a/tests/methods.cc
+++ b/tests/methods.cc
@@ -23,6 +23,7 @@ void register_user_methods(iqxmlrpc::Server& s)
   register_method(s, "error_method", error_method);
   register_method(s, "std_exception_method", std_exception_method);
   register_method(s, "unknown_exception_method", unknown_exception_method);
+  register_method(s, "library_exception_method", library_exception_method);
   register_method(s, "trace", trace_method);
   register_method(s, "sleep", sleep_method);
   register_method<Get_file>(s, "get_file");
@@ -110,6 +111,15 @@ void unknown_exception_method(
 {
   THREAD_SAFE_TEST_MESSAGE("unknown_exception_method invoked.");
   throw 42;  // Throw a non-exception type
+}
+
+void library_exception_method(
+  iqxmlrpc::Method* /*m*/,
+  const iqxmlrpc::Param_list&,
+  iqxmlrpc::Value& /*retval*/ )
+{
+  THREAD_SAFE_TEST_MESSAGE("library_exception_method invoked.");
+  throw iqxmlrpc::Invalid_meth_params();
 }
 
 void Get_file::execute( 

--- a/tests/methods.h
+++ b/tests/methods.h
@@ -22,6 +22,7 @@ void trace_method(iqxmlrpc::Method*, const iqxmlrpc::Param_list&, iqxmlrpc::Valu
 void error_method(iqxmlrpc::Method*, const iqxmlrpc::Param_list&, iqxmlrpc::Value&);
 void std_exception_method(iqxmlrpc::Method*, const iqxmlrpc::Param_list&, iqxmlrpc::Value&);
 void unknown_exception_method(iqxmlrpc::Method*, const iqxmlrpc::Param_list&, iqxmlrpc::Value&);
+void library_exception_method(iqxmlrpc::Method*, const iqxmlrpc::Param_list&, iqxmlrpc::Value&);
 void sleep_method(iqxmlrpc::Method*, const iqxmlrpc::Param_list&, iqxmlrpc::Value&);
 
 class Get_file: public iqxmlrpc::Method {


### PR DESCRIPTION
## Summary

- Replace `e.what()` with generic `"Internal server error"` in client-facing XML-RPC fault responses (CWE-209)
- Add `iqxmlrpc::Exception` catch handler to `Pool_executor` for serial/pool parity — library exceptions preserve XML-RPC interop fault codes
- Add server-side logging for all non-Fault exceptions in pool executor path
- Extract `GENERIC_FAULT_MSG` constant in both `server.cc` and `executor.cc`

## Motivation

SSL/TLS errors, file paths, and system internals were leaked to remote clients via `e.what()` in XML-RPC `<faultString>`. This aids reconnaissance by exposing OpenSSL error codes, cipher names, and library versions.

## Design decisions

- **`Fault` messages preserved as-is** — they are application-controlled (thrown by user methods), intentionally sent to clients
- **`iqxmlrpc::Exception` messages preserved** — they carry XML-RPC spec-defined fault codes (e.g., `-32602` Invalid params)
- **`std::exception` and `catch(...)` sanitized** — these may contain internal details; generic message sent to client, detail logged server-side
- **Dual contract tested** — each test verifies both that the client receives a generic message AND that the server log contains the original detail

## Files changed

| File | Change |
|------|--------|
| `libiqxmlrpc/server.cc` | Sanitize `std::exception`/`catch(...)` handlers; extract `GENERIC_FAULT_MSG` |
| `libiqxmlrpc/executor.cc` | Sanitize pool executor handlers; add `iqxmlrpc::Exception` catch; add logging; extract `GENERIC_FAULT_MSG` |
| `libiqxmlrpc/executor.h` | Add `log_err_msg()` declaration |
| `tests/test_integration_server.cc` | Add 8 CWE-209 dual-contract tests (log + client message) for all exception types × both executors |
| `tests/test_thread_safety.cc` | Exercise all 4 pool executor catch paths; verify generic messages |
| `tests/methods.cc` | Add `library_exception_method` (throws `Invalid_meth_params`) |
| `tests/methods.h` | Declare `library_exception_method` |

## Test plan

- [x] `make check` passes (21 tests)
- [x] Integration tests verify generic fault string for `std::exception` (serial + pool)
- [x] Integration tests verify generic fault string for unknown exceptions (serial + pool)
- [x] Integration tests verify `iqxmlrpc::Exception` preserves fault code and message (serial + pool)
- [x] Integration tests verify server log contains internal detail for all exception types
- [x] Thread safety tests exercise all 4 pool executor catch paths
- [x] `Fault` messages still pass through unchanged (fault code 123, "My fault")