### PR TITLE
cleanup: Rename Header::get_xheaders/set_xheaders to get_headers/set_headers

### DIFF
--- a/fuzz/fuzz_http.cc
+++ b/fuzz/fuzz_http.cc
@@ -29,9 +29,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
       std::string user, password;
       req_hdr.get_authinfo(user, password);
     }
-    // Exercise X-headers parsing
+    // Exercise custom header parsing
     iqxmlrpc::XHeaders xhdrs;
-    req_hdr.get_xheaders(xhdrs);
+    req_hdr.get_headers(xhdrs);
   } catch (...) {
     // Exceptions are expected for malformed input
   }

--- a/libiqxmlrpc/client_conn.cc
+++ b/libiqxmlrpc/client_conn.cc
@@ -32,8 +32,8 @@ Response Client_connection::process_session( const Request& req, const XHeaders&
   if (opts().has_authinfo())
     req_h->set_authinfo( opts().auth_user(), opts().auth_passwd() );
 
-  req_h->set_xheaders( opts().xheaders() );
-  req_h->set_xheaders( xheaders );
+  req_h->set_headers( opts().xheaders() );
+  req_h->set_headers( xheaders );
 
   Packet req_p( req_h.release(), req_xml_str );
   req_p.set_keep_alive( opts().keep_alive() );

--- a/libiqxmlrpc/http.cc
+++ b/libiqxmlrpc/http.cc
@@ -487,7 +487,7 @@ std::string Request_header::agent() const
   return get_string(names::user_agent);
 }
 
-void Header::get_xheaders(iqxmlrpc::XHeaders& xheaders) const
+void Header::get_headers(iqxmlrpc::XHeaders& xheaders) const
 {
   // Clear first to prevent stale headers from persisting when object is reused
   xheaders = std::map<std::string, std::string>();
@@ -497,7 +497,7 @@ void Header::get_xheaders(iqxmlrpc::XHeaders& xheaders) const
   }
 }
 
-void Header::set_xheaders(const iqxmlrpc::XHeaders& xheaders)
+void Header::set_headers(const iqxmlrpc::XHeaders& xheaders)
 {
   for (const auto& header : xheaders) {
     set_option(header.first, header.second);

--- a/libiqxmlrpc/http.h
+++ b/libiqxmlrpc/http.h
@@ -88,8 +88,8 @@ public:
   void set_conn_keep_alive( bool );
   void set_option(const std::string& name, const std::string& value);
 
-  void get_xheaders(iqxmlrpc::XHeaders& xheaders) const;
-  void set_xheaders(const iqxmlrpc::XHeaders& xheaders);
+  void get_headers(iqxmlrpc::XHeaders& xheaders) const;
+  void set_headers(const iqxmlrpc::XHeaders& xheaders);
 
   //! Return text representation of header including final CRLF.
   std::string dump() const;

--- a/libiqxmlrpc/server.cc
+++ b/libiqxmlrpc/server.cc
@@ -290,7 +290,7 @@ void Server::schedule_execute( http::Packet* pkt, Server_connection* conn )
     if (authname)
       meth->authname(*authname);
 
-    pkt->header()->get_xheaders(meth->xheaders());
+    pkt->header()->get_headers(meth->xheaders());
 
     executor = impl->exec_factory->create( meth, this, conn );
     executor->set_interceptors(impl->interceptors.get());

--- a/tests/test_crlf_injection.cc
+++ b/tests/test_crlf_injection.cc
@@ -37,7 +37,7 @@ BOOST_AUTO_TEST_CASE(header_injection_via_xheaders_rejected)
     xheaders["X-Legitimate"] = "normal-value\r\nX-Injected: malicious-payload";
 
     // VERIFY: Exception is thrown when setting xheaders
-    BOOST_CHECK_THROW(hdr.set_xheaders(xheaders), Http_header_error);
+    BOOST_CHECK_THROW(hdr.set_headers(xheaders), Http_header_error);
 }
 
 /**
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(session_fixation_via_cookie_injection_rejected)
     // ATTACK ATTEMPT: Inject a Set-Cookie header to fix session
     xheaders["X-Tracking"] = "id123\r\nSet-Cookie: session=attacker-controlled; Path=/";
 
-    BOOST_CHECK_THROW(hdr.set_xheaders(xheaders), Http_header_error);
+    BOOST_CHECK_THROW(hdr.set_headers(xheaders), Http_header_error);
 }
 
 /**
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(cache_poisoning_rejected)
     // ATTACK ATTEMPT: Inject cache-control to poison intermediate caches
     xheaders["X-Request-Id"] = "abc\r\nCache-Control: public, max-age=31536000\r\nX-Poison: true";
 
-    BOOST_CHECK_THROW(hdr.set_xheaders(xheaders), Http_header_error);
+    BOOST_CHECK_THROW(hdr.set_headers(xheaders), Http_header_error);
 }
 
 /**
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(response_splitting_rejected)
     // Double CRLF ends headers, then inject fake content
     xheaders["X-Debug"] = "value\r\n\r\n<html><script>alert('XSS')</script></html>";
 
-    BOOST_CHECK_THROW(hdr.set_xheaders(xheaders), Http_header_error);
+    BOOST_CHECK_THROW(hdr.set_headers(xheaders), Http_header_error);
 }
 
 /**
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE(cr_only_injection_rejected)
     // ATTACK ATTEMPT: Use only \r (some servers/proxies may treat this as newline)
     xheaders["X-Test"] = "value\rX-Injected-CR: via-carriage-return";
 
-    BOOST_CHECK_THROW(hdr.set_xheaders(xheaders), Http_header_error);
+    BOOST_CHECK_THROW(hdr.set_headers(xheaders), Http_header_error);
 }
 
 /**
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(lf_only_injection_rejected)
     // ATTACK ATTEMPT: Use only \n (HTTP/1.1 allows LF-only line endings)
     xheaders["X-Test"] = "value\nX-Injected-LF: via-line-feed";
 
-    BOOST_CHECK_THROW(hdr.set_xheaders(xheaders), Http_header_error);
+    BOOST_CHECK_THROW(hdr.set_headers(xheaders), Http_header_error);
 }
 
 /**
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(legitimate_headers_work)
     xheaders["X-Numeric"] = "12345";
 
     // Should NOT throw
-    BOOST_CHECK_NO_THROW(hdr.set_xheaders(xheaders));
+    BOOST_CHECK_NO_THROW(hdr.set_headers(xheaders));
 
     // Verify headers are actually set by checking dump
     // Note: XHeaders converts names to lowercase (x-request-id not X-Request-Id)


### PR DESCRIPTION
## Summary

- Rename `Header::get_xheaders()` to `Header::get_headers()` and `Header::set_xheaders()` to `Header::set_headers()`
- Mark Finding #16 as Won't Fix (by design)

## Motivation

The old names implied `x-*` prefix filtering, but these methods copy **all** HTTP headers to/from the `XHeaders` map. Applications rely on custom non-`x-*` headers, so the behavior is correct — only the naming was misleading.

The public API (`Client::set_xheaders()`, `Method::xheaders()`) is unchanged. The rename is limited to the internal `Header` class on the HTTP layer.

## Security Finding #16 — Won't Fix

Forwarding all headers is by design. The `header_max_sz` (16KB default) bounds both count and total size, CRLF injection is blocked by `validate_header_crlf()`, and the `XHeaders` map is a per-request copy — making namespace pollution impractical.

## Test plan

- [x] `make check` passes (21/21 tests)
- [x] No remaining `get_xheaders`/`set_xheaders` references in source files
- [x] Mechanical 1:1 rename — no behavior change