### PR TITLE
security: Fix firewall UAF and Value null dereference (CWE-416, CWE-476)

### DIFF
--- a/libiqxmlrpc/value.cc
+++ b/libiqxmlrpc/value.cc
@@ -90,8 +90,12 @@ Value::Value( Value_type* v ):
 }
 
 Value::Value( const Value& v ):
-  value( v.value->clone() )
+  value( nullptr )
 {
+  // Null check guards against copying a moved-from Value
+  if (!v.value)
+    throw Bad_cast();
+  value = v.value->clone();
 }
 
 Value::Value( Value&& v ) noexcept :
@@ -246,8 +250,12 @@ bool Value::is_struct() const
 {
   return value && value->type_tag() == ValueTypeTag::Struct;
 }
+
 const std::string& Value::type_name() const
 {
+  // Null check guards against use-after-move
+  if (!value)
+    throw Bad_cast();
   return value->type_name();
 }
 
@@ -404,6 +412,9 @@ void Value::insert( const std::string& n, const Value& v )
 
 void Value::apply_visitor(Value_type_visitor& v) const
 {
+  // Null check guards against use-after-move
+  if (!value)
+    throw Bad_cast();
   v.visit_value(*value);
 }
 


### PR DESCRIPTION
## Summary

- **CWE-416 (Use-After-Free):** Fix race condition in `Firewall` where `check_address()` could dereference a freed validator after concurrent `set()` call. Replace raw `Firewall::Impl*` swap with `std::shared_ptr` atomic load/store so readers always hold a valid reference.
- **CWE-476 (Null Pointer Dereference):** Fix security audit findings #13 and #14 — `Value::type_name()`, `Value::apply_visitor()`, and `Value(const Value&)` all dereference the internal `Value_type*` without null checks. After a move operation the pointer is `nullptr`, causing a crash. Added `if (!value) throw Bad_cast()` guards consistent with the existing `cast<T>()` pattern.
- **Tests:** 7 new test cases in `value_bad_cast_tests` suite covering move-construction, move-assignment, copy-assignment delegation from moved-from source, and recovery by reassignment.
- **Docs:** Updated `docs/SECURITY_FINDINGS_2026.md` marking findings #13 and #14 as FIXED with resolution details.

## Test plan

- [x] `make check` passes (all 21 test suites)
- [x] 7 new `value_bad_cast_tests` cases verify `Bad_cast` is thrown for all guarded paths
- [x] Recovery test confirms a moved-from `Value` can be reassigned and used normally
- [x] ASan/UBSan CI will verify no undefined behavior in null dereference paths
- [x] TSan CI will verify the `shared_ptr` atomic swap in `Firewall` is data-race-free