### PR TITLE
perf: Move shared_ptr instead of copying on last use (CID 644055)

### DIFF
--- a/libiqxmlrpc/server.cc
+++ b/libiqxmlrpc/server.cc
@@ -362,7 +362,7 @@ void Server::set_firewall( iqnet::Firewall_base* _firewall )
   std::lock_guard<std::mutex> lock(impl->acceptor_mutex);
   std::atomic_store(&impl->firewall, fw);
   if (impl->acceptor)
-    impl->acceptor->set_firewall(fw);
+    impl->acceptor->set_firewall(std::move(fw));
 }
 
 void Server::check_idle_timeouts()


### PR DESCRIPTION
## Summary
- Fix Coverity CID 644055 (COPY_INSTEAD_OF_MOVE) in `Server::set_firewall()`
- Use `std::move(fw)` on the last use of the local `shared_ptr`, avoiding an unnecessary atomic ref-count increment/decrement pair

## Test plan
- [ ] Library compiles without warnings
- [ ] All CI checks pass (no behavioral change — move vs copy of shared_ptr)
- [ ] Verify Coverity CID 644055 is resolved in next scan