### PR TITLE
chore: Suppress Coverity CID 644056 false positive (MISSING_LOCK)

### DIFF
--- a/libiqxmlrpc/server.cc
+++ b/libiqxmlrpc/server.cc
@@ -214,6 +214,7 @@ void Server::register_connection(Server_connection* conn)
 void Server::unregister_connection(Server_connection* conn)
 {
   // SECURITY: Notify firewall that connection is closing for accurate tracking.
+  // coverity[MISSING_LOCK : FALSE_POSITIVE] - std::atomic_load provides lock-free synchronization
   auto fw = std::atomic_load(&impl->firewall);
   if (fw) {
     try {


### PR DESCRIPTION
## Summary
- Add Coverity suppression comment for CID 644056 (MISSING_LOCK) in `Server::unregister_connection()`
- This is a **false positive**: `std::atomic_load` on `shared_ptr` provides lock-free thread-safe access (C++11 §20.7.2.5)
- All three access sites to `impl->firewall` use `atomic_load`/`atomic_store`; there is no unprotected access

## Test plan
- [ ] CI passes (comment-only change)
- [ ] Coverity CID 644056 suppressed in next scan