### PR TITLE
chore: Add Coverity CTOR_DTOR_LEAK suppression at constructor site (CID 641369)

### DIFF
--- a/libiqxmlrpc/socket.cc
+++ b/libiqxmlrpc/socket.cc
@@ -20,6 +20,7 @@ Socket::Socket():
 {
   // cppcheck-suppress useInitializationList
   // Cannot use initializer list: need to check socket() return value for errors
+  // coverity[CTOR_DTOR_LEAK : FALSE_POSITIVE] - Socket uses explicit close() by design
   sock = socket( PF_INET, SOCK_STREAM, IPPROTO_TCP );
   if( sock == -1 )
     throw network_error( "Socket::Socket" );


### PR DESCRIPTION
## Summary
- Add `coverity[CTOR_DTOR_LEAK : FALSE_POSITIVE]` suppression at the `socket()` call in `socket.cc:23` where Coverity flags the allocation
- Existing suppression on the destructor (`socket.h:34`) may not cover the constructor-side finding
- The design is intentional: `Socket` uses explicit `close()` to support value semantics and ownership transfer from `accept()`

## Test plan
- [ ] CI passes (comment-only change)
- [ ] Coverity CID 641369 suppressed in next scan