### PR TITLE
docs: Close security findings #12, #15 as won't-fix (by design)

### DIFF
--- a/docs/HARDENING_GUIDE.md
+++ b/docs/HARDENING_GUIDE.md
@@ -26,6 +26,11 @@ server.set_max_request_sz(10 * 1024 * 1024);  // 10 MB
 
 **Recommendation:** 10 MB covers most XML-RPC payloads. Set lower if your methods only accept small parameters.
 
+**Memory note:** XML parsing temporarily requires ~2x the value size in memory
+(libxml2 internal buffer + application string). A 100 MB request body may use
+~200 MB of heap during parsing. Factor this into your `max_request_sz` setting
+relative to available server memory.
+
 ### Idle Connection Timeout
 
 Prevents Slow Loris attacks — connections that send data slowly to hold server resources (Finding #8).


### PR DESCRIPTION
## Summary

- **Finding #12 (`XML_PARSE_HUGE`):** Closed as won't-fix. Required for 100 MB+ payload transfers; `set_max_request_sz()` provides the configurable outer bound. Added memory amplification note to `docs/HARDENING_GUIDE.md`.
- **Finding #15 (pipelined HTTP data discarded):** Closed as won't-fix. XML-RPC is request-response; discarding excess bytes is safer than buffering unsolicited data.

With these changes, all 18 security audit findings are now resolved (14 fixed, 4 won't-fix).

Documentation-only — no code changes.

## Test plan

- [ ] Verify `docs/SECURITY_FINDINGS_2026.md` status counts are correct (14 fixed, 4 won't-fix, 0 open)
- [ ] Verify `docs/HARDENING_GUIDE.md` memory amplification note is in the Request Size Limit section
- [ ] No build/test needed (docs-only change)