### PR TITLE
chore: Release 0.14.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(Libiqxmlrpc)
-set(Libiqxmlrpc_VERSION 0.14.1)
+set(Libiqxmlrpc_VERSION 0.14.2)
 
 # Require C++17 standard for entire project
 set(CMAKE_CXX_STANDARD 17)

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,42 @@
 Look into ChangeLog file for full list of changes.
 
+0.14.1 - 0.14.2
+  Security Fixes:
+    * Fix client-side TLS certificate validation disabled by default (CWE-295)
+    * Fix use-after-free in Pool_executor via ConnectionGuard (CWE-416)
+    * Fix TOCTOU race on global SSL context hostname (CWE-367)
+    * Fix data race on global mutable ValueOptions (CWE-362)
+    * Fix HTTP request smuggling via Transfer-Encoding (CWE-444)
+    * Fix integer truncation size_t to int on XML buffer (CWE-197)
+    * Fix firewall use-after-free via shared_ptr atomic swap (CWE-416)
+    * Fix SSL error messages leaked to clients (CWE-209)
+    * Add opt-in TLS enforcement for authentication (CWE-319)
+    * Fix null dereference on moved-from Value (CWE-476)
+    * Fix unchecked gethostname() return value (CWE-252)
+    * Fix memory leak via unique_ptr for resp_packet (CWE-401)
+    * Add method name length limit at parse time (CWE-20)
+
+  New Features:
+    * Client-side response size limit API (set_max_response_sz)
+    * Per-connection SSL hostname verification (thread-safe)
+    * TLS auth enforcement API (require_tls_for_auth)
+    * Comprehensive hardening guide (docs/HARDENING_GUIDE.md)
+
+  Performance Optimizations:
+    * Move semantics for parsed text in value builder (~17% RPS)
+    * Move semantics for request parameter passing
+    * Cache HTTP Date header to avoid redundant gmtime/strftime
+    * Use xmlTextReaderConst* to eliminate xmlStrdup per parse step
+    * Move shared_ptr instead of copying on last use
+
+  Refactoring:
+    * Return unique_ptr from Packet_reader, Client_connection, do_process_session
+    * Document breaking API changes since 0.13.8
+
+  Security Audit:
+    * Full codebase audit: 18 findings (14 fixed, 4 won't-fix by design)
+    * Documented in docs/SECURITY_FINDINGS_2026.md
+
 0.14.0 - 0.14.1
   New Features:
     * Allow arbitrary custom HTTP headers (RFC 6648 compliance, removes X- prefix restriction)


### PR DESCRIPTION
## Summary

Version bump to 0.14.2 — security audit release.

- Bumps `Libiqxmlrpc_VERSION` in CMakeLists.txt from 0.14.1 to 0.14.2
- Updates NEWS with full changelog since 0.14.1

### What's in 0.14.2

**Security Fixes (13):**
- Client-side TLS certificate validation (CWE-295)
- Pool_executor use-after-free via ConnectionGuard (CWE-416)
- TOCTOU race on global SSL context hostname (CWE-367)
- Data race on global mutable ValueOptions (CWE-362)
- HTTP request smuggling via Transfer-Encoding (CWE-444)
- Integer truncation size_t to int on XML buffer (CWE-197)
- Firewall use-after-free via shared_ptr atomic swap (CWE-416)
- SSL error messages leaked to clients (CWE-209)
- Opt-in TLS enforcement for authentication (CWE-319)
- Null dereference on moved-from Value (CWE-476)
- Unchecked gethostname() return value (CWE-252)
- Memory leak via unique_ptr for resp_packet (CWE-401)
- Method name length limit at parse time (CWE-20)

**New Features:** Client response size limit, per-connection SSL hostname verification, TLS auth enforcement API, hardening guide

**Performance:** Move semantics (~17% RPS), HTTP Date caching, xmlTextReaderConst*, shared_ptr move

**Security Audit:** 18 findings total — 14 fixed, 4 won't-fix (by design). Full report in `docs/SECURITY_FINDINGS_2026.md`.

## Test plan

- [ ] CI passes (no code changes, version bump + NEWS only)
- [ ] After merge, tag `0.14.2` and create GitHub release