### PR TITLE
fix(ssl): clear per-thread OpenSSL error queue before SSL I/O

### DIFF
--- a/libiqxmlrpc/ssl_connection.cc
+++ b/libiqxmlrpc/ssl_connection.cc
@@ -62,6 +62,9 @@ void ssl::Connection::prepare_for_ssl_connect()
 void ssl::Connection::ssl_accept()
 {
   prepare_for_ssl_accept();
+  // Empty queue is a precondition of SSL_get_error() (consulted inside
+  // throw_io_exception() below).
+  ERR_clear_error();
   int ret = SSL_accept( ssl );
 
   if( ret != 1 )
@@ -95,6 +98,7 @@ void ssl::Connection::prepare_hostname_for_connect()
 void ssl::Connection::ssl_connect()
 {
   prepare_for_ssl_connect();
+  ERR_clear_error();
   int ret = SSL_connect( ssl );
 
   if( ret != 1 )
@@ -107,6 +111,7 @@ void ssl::Connection::shutdown()
   if( shutdown_recved() && shutdown_sent() )
     return;
 
+  ERR_clear_error();
   int ret = SSL_shutdown( ssl );
   switch( ret )
   {
@@ -114,6 +119,7 @@ void ssl::Connection::shutdown()
       return;
 
     case 0:
+      ERR_clear_error();
       SSL_shutdown( ssl );
       SSL_set_shutdown( ssl, SSL_RECEIVED_SHUTDOWN );
       break;
@@ -141,6 +147,7 @@ size_t ssl::Connection::send( const char* data, size_t len )
 
   while( total_written < len )
   {
+    ERR_clear_error();
     int ret = SSL_write( ssl, data + total_written,
                          static_cast<int>(len - total_written) );
 
@@ -163,6 +170,7 @@ size_t ssl::Connection::recv( char* buf, size_t len )
     throw exception("SSL::recv: buffer size exceeds INT_MAX");
   }
 
+  ERR_clear_error();
   int ret = SSL_read( ssl, buf, static_cast<int>(len) );
 
   if( ret <= 0 )
@@ -200,9 +208,10 @@ ssl::SslIoResult ssl::Connection::try_ssl_read( char* buf, size_t len, size_t& b
   }
 
   bytes_read = 0;
-  // SSL_get_error() in check_io_result() inspects the per-thread OpenSSL
-  // error queue; a stale entry left by an earlier unrelated call would
-  // mask a benign WANT_READ as SSL_ERROR_SSL. Clear before every SSL_* call.
+  // Clear stale entries before SSL_get_error() inspects the queue.
+  // A lingering entry from earlier unrelated OpenSSL work (verify callback,
+  // BIO helper, parallel teardown) would mask a benign WANT_READ as
+  // SSL_ERROR_SSL. Contract required by SSL_get_error(3).
   ERR_clear_error();
   int ret = SSL_read( ssl, buf, static_cast<int>(len) );
 
@@ -226,7 +235,7 @@ ssl::SslIoResult ssl::Connection::try_ssl_write( const char* buf, size_t len, si
   }
 
   bytes_written = 0;
-  // See try_ssl_read() for rationale.
+  // Clear stale entries before SSL_get_error() inspects the queue.
   ERR_clear_error();
   int ret = SSL_write( ssl, buf, static_cast<int>(len) );
 
@@ -242,7 +251,7 @@ ssl::SslIoResult ssl::Connection::try_ssl_write( const char* buf, size_t len, si
 
 ssl::SslIoResult ssl::Connection::try_ssl_accept_nonblock()
 {
-  // See try_ssl_read() for rationale.
+  // Clear stale entries before SSL_get_error() inspects the queue.
   ERR_clear_error();
   int ret = SSL_accept( ssl );
 
@@ -257,7 +266,7 @@ ssl::SslIoResult ssl::Connection::try_ssl_accept_nonblock()
 
 ssl::SslIoResult ssl::Connection::try_ssl_connect_nonblock()
 {
-  // See try_ssl_read() for rationale.
+  // Clear stale entries before SSL_get_error() inspects the queue.
   ERR_clear_error();
   int ret = SSL_connect( ssl );
 
@@ -276,7 +285,7 @@ ssl::SslIoResult ssl::Connection::try_ssl_shutdown_nonblock()
     return SslIoResult::OK;
   }
 
-  // See try_ssl_read() for rationale.
+  // Clear stale entries before SSL_get_error() inspects the queue.
   ERR_clear_error();
   int ret = SSL_shutdown( ssl );
 
@@ -285,10 +294,22 @@ ssl::SslIoResult ssl::Connection::try_ssl_shutdown_nonblock()
   }
 
   if( ret == 0 ) {
-    // First phase of bidirectional shutdown complete, need to call again
+    // Phase 1 complete (our close_notify sent). Try phase 2 to read peer's
+    // close_notify. Mark SSL_RECEIVED_SHUTDOWN regardless so we don't hang
+    // on peers that never ack (preserves the original tear-down semantics),
+    // but surface real protocol errors instead of swallowing them.
     ERR_clear_error();
-    SSL_shutdown( ssl );
+    int ret2 = SSL_shutdown( ssl );
     SSL_set_shutdown( ssl, SSL_RECEIVED_SHUTDOWN );
+    if( ret2 < 0 ) {
+      bool clean_close = false;
+      SslIoResult phase2 = check_io_result( ssl, ret2, clean_close );
+      if( phase2 == SslIoResult::ERROR ||
+          phase2 == SslIoResult::CONNECTION_CLOSE ) {
+        return phase2;
+      }
+      // WANT_READ / WANT_WRITE: peer hasn't ack'd, not worth polling.
+    }
     return SslIoResult::OK;
   }
 
@@ -396,8 +417,17 @@ void ssl::Reaction_connection::switch_state( bool& terminate )
       size_t bytes_written = 0;
       result = try_ssl_write( send_buf, buf_len, bytes_written );
       if( result == SslIoResult::OK ) {
-        state = EMPTY;
-        send_succeed( terminate );
+        if( bytes_written < buf_len ) {
+          // Partial write (possible if SSL_MODE_ENABLE_PARTIAL_WRITE is
+          // ever enabled). Advance and stay in WRITING so the next writable
+          // event flushes the tail instead of silently dropping it.
+          send_buf += bytes_written;
+          buf_len  -= bytes_written;
+          result = SslIoResult::WANT_WRITE;
+        } else {
+          state = EMPTY;
+          send_succeed( terminate );
+        }
       }
       break;
     }

--- a/libiqxmlrpc/ssl_connection.cc
+++ b/libiqxmlrpc/ssl_connection.cc
@@ -426,8 +426,9 @@ void ssl::Reaction_connection::switch_state( bool& terminate )
         if( bytes_written < buf_len ) {
           // SSL_write may return fewer bytes than requested; advance and
           // stay in WRITING so the next writable event flushes the tail.
-          // Dormant-by-design in libiqxmlrpc (SSL_MODE_ENABLE_PARTIAL_WRITE
-          // is never set) but defends against the silent-truncation trap.
+          // Typically dormant (this library does not currently enable
+          // SSL_MODE_ENABLE_PARTIAL_WRITE) but defends against silent
+          // truncation if that changes.
           send_buf += bytes_written;
           buf_len  -= bytes_written;
           result = SslIoResult::WANT_WRITE;
@@ -441,7 +442,14 @@ void ssl::Reaction_connection::switch_state( bool& terminate )
 
     case SHUTDOWN:
       result = try_ssl_shutdown_nonblock();
-      if( result == SslIoResult::OK ) {
+      // OK and CONNECTION_CLOSE are both terminal: the former means the
+      // handshake-level shutdown completed; the latter means the wrapper
+      // decided retrying is pointless (peer gone, phase-2 error, etc.).
+      // Without setting terminate here for CONNECTION_CLOSE, reg_shutdown()
+      // would take its "both flags already set" branch, free no handler,
+      // and orphan the connection.
+      if( result == SslIoResult::OK ||
+          result == SslIoResult::CONNECTION_CLOSE ) {
         terminate = true;
       }
       break;

--- a/libiqxmlrpc/ssl_connection.cc
+++ b/libiqxmlrpc/ssl_connection.cc
@@ -62,8 +62,7 @@ void ssl::Connection::prepare_for_ssl_connect()
 void ssl::Connection::ssl_accept()
 {
   prepare_for_ssl_accept();
-  // Empty queue is a precondition of SSL_get_error() (consulted inside
-  // throw_io_exception() below).
+  // Clear stale entries before SSL_get_error() inspects the queue.
   ERR_clear_error();
   int ret = SSL_accept( ssl );
 
@@ -98,6 +97,7 @@ void ssl::Connection::prepare_hostname_for_connect()
 void ssl::Connection::ssl_connect()
 {
   prepare_for_ssl_connect();
+  // Clear stale entries before SSL_get_error() inspects the queue.
   ERR_clear_error();
   int ret = SSL_connect( ssl );
 
@@ -111,6 +111,7 @@ void ssl::Connection::shutdown()
   if( shutdown_recved() && shutdown_sent() )
     return;
 
+  // Clear stale entries before SSL_get_error() inspects the queue.
   ERR_clear_error();
   int ret = SSL_shutdown( ssl );
   switch( ret )
@@ -119,6 +120,7 @@ void ssl::Connection::shutdown()
       return;
 
     case 0:
+      // Clear stale entries before SSL_get_error() inspects the queue.
       ERR_clear_error();
       SSL_shutdown( ssl );
       SSL_set_shutdown( ssl, SSL_RECEIVED_SHUTDOWN );
@@ -147,6 +149,7 @@ size_t ssl::Connection::send( const char* data, size_t len )
 
   while( total_written < len )
   {
+    // Clear stale entries before SSL_get_error() inspects the queue.
     ERR_clear_error();
     int ret = SSL_write( ssl, data + total_written,
                          static_cast<int>(len - total_written) );
@@ -170,6 +173,7 @@ size_t ssl::Connection::recv( char* buf, size_t len )
     throw exception("SSL::recv: buffer size exceeds INT_MAX");
   }
 
+  // Clear stale entries before SSL_get_error() inspects the queue.
   ERR_clear_error();
   int ret = SSL_read( ssl, buf, static_cast<int>(len) );
 
@@ -294,10 +298,11 @@ ssl::SslIoResult ssl::Connection::try_ssl_shutdown_nonblock()
   }
 
   if( ret == 0 ) {
-    // Phase 1 complete (our close_notify sent). Try phase 2 to read peer's
-    // close_notify. Mark SSL_RECEIVED_SHUTDOWN regardless so we don't hang
-    // on peers that never ack (preserves the original tear-down semantics),
-    // but surface real protocol errors instead of swallowing them.
+    // Phase 1 done (our close_notify sent); try phase 2 to read peer's.
+    // Mark SSL_RECEIVED_SHUTDOWN unconditionally so non-ack'ing peers can't
+    // wedge us. A real phase-2 error becomes CONNECTION_CLOSE (graceful
+    // reactor tear-down) rather than a thrown ssl::exception from a
+    // teardown path that previously couldn't throw.
     ERR_clear_error();
     int ret2 = SSL_shutdown( ssl );
     SSL_set_shutdown( ssl, SSL_RECEIVED_SHUTDOWN );
@@ -306,9 +311,10 @@ ssl::SslIoResult ssl::Connection::try_ssl_shutdown_nonblock()
       SslIoResult phase2 = check_io_result( ssl, ret2, clean_close );
       if( phase2 == SslIoResult::ERROR ||
           phase2 == SslIoResult::CONNECTION_CLOSE ) {
-        return phase2;
+        return SslIoResult::CONNECTION_CLOSE;
       }
-      // WANT_READ / WANT_WRITE: peer hasn't ack'd, not worth polling.
+      // WANT_READ / WANT_WRITE: peer hasn't ack'd; cheaper to drop the
+      // connection than to re-poll indefinitely. Reactor tear-down follows.
     }
     return SslIoResult::OK;
   }
@@ -418,9 +424,10 @@ void ssl::Reaction_connection::switch_state( bool& terminate )
       result = try_ssl_write( send_buf, buf_len, bytes_written );
       if( result == SslIoResult::OK ) {
         if( bytes_written < buf_len ) {
-          // Partial write (possible if SSL_MODE_ENABLE_PARTIAL_WRITE is
-          // ever enabled). Advance and stay in WRITING so the next writable
-          // event flushes the tail instead of silently dropping it.
+          // SSL_write may return fewer bytes than requested; advance and
+          // stay in WRITING so the next writable event flushes the tail.
+          // Dormant-by-design in libiqxmlrpc (SSL_MODE_ENABLE_PARTIAL_WRITE
+          // is never set) but defends against the silent-truncation trap.
           send_buf += bytes_written;
           buf_len  -= bytes_written;
           result = SslIoResult::WANT_WRITE;

--- a/libiqxmlrpc/ssl_connection.cc
+++ b/libiqxmlrpc/ssl_connection.cc
@@ -200,6 +200,10 @@ ssl::SslIoResult ssl::Connection::try_ssl_read( char* buf, size_t len, size_t& b
   }
 
   bytes_read = 0;
+  // SSL_get_error() in check_io_result() inspects the per-thread OpenSSL
+  // error queue; a stale entry left by an earlier unrelated call would
+  // mask a benign WANT_READ as SSL_ERROR_SSL. Clear before every SSL_* call.
+  ERR_clear_error();
   int ret = SSL_read( ssl, buf, static_cast<int>(len) );
 
   if( ret > 0 ) {
@@ -222,6 +226,8 @@ ssl::SslIoResult ssl::Connection::try_ssl_write( const char* buf, size_t len, si
   }
 
   bytes_written = 0;
+  // See try_ssl_read() for rationale.
+  ERR_clear_error();
   int ret = SSL_write( ssl, buf, static_cast<int>(len) );
 
   if( ret > 0 ) {
@@ -236,6 +242,8 @@ ssl::SslIoResult ssl::Connection::try_ssl_write( const char* buf, size_t len, si
 
 ssl::SslIoResult ssl::Connection::try_ssl_accept_nonblock()
 {
+  // See try_ssl_read() for rationale.
+  ERR_clear_error();
   int ret = SSL_accept( ssl );
 
   if( ret == 1 ) {
@@ -249,6 +257,8 @@ ssl::SslIoResult ssl::Connection::try_ssl_accept_nonblock()
 
 ssl::SslIoResult ssl::Connection::try_ssl_connect_nonblock()
 {
+  // See try_ssl_read() for rationale.
+  ERR_clear_error();
   int ret = SSL_connect( ssl );
 
   if( ret == 1 ) {
@@ -266,6 +276,8 @@ ssl::SslIoResult ssl::Connection::try_ssl_shutdown_nonblock()
     return SslIoResult::OK;
   }
 
+  // See try_ssl_read() for rationale.
+  ERR_clear_error();
   int ret = SSL_shutdown( ssl );
 
   if( ret == 1 ) {
@@ -274,6 +286,7 @@ ssl::SslIoResult ssl::Connection::try_ssl_shutdown_nonblock()
 
   if( ret == 0 ) {
     // First phase of bidirectional shutdown complete, need to call again
+    ERR_clear_error();
     SSL_shutdown( ssl );
     SSL_set_shutdown( ssl, SSL_RECEIVED_SHUTDOWN );
     return SslIoResult::OK;

--- a/tests/test_integration_common.h
+++ b/tests/test_integration_common.h
@@ -12,6 +12,7 @@
 #include <cstdio>
 #include <fcntl.h>
 #include <fstream>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
@@ -322,6 +323,11 @@ protected:
   std::string temp_cert_path_;
   std::string temp_key_path_;
   std::string server_error_message_;
+  // Optional hook: runs synchronously inside start_server(), after the
+  // built-in user methods are registered but before the reactor thread
+  // begins work(). Tests use this to register additional methods safely
+  // (the dispatcher map is not thread-safe once work() starts).
+  std::function<void(iqxmlrpc::Server&)> extra_registration_hook_;
 
 public:
   HttpsIntegrationFixture(const HttpsIntegrationFixture&) = delete;
@@ -338,6 +344,7 @@ public:
     , temp_cert_path_()
     , temp_key_path_()
     , server_error_message_()
+    , extra_registration_hook_()
   {}
 
   ~HttpsIntegrationFixture() {
@@ -385,6 +392,10 @@ public:
       exec_factory_.get());
 
     register_user_methods(*server_);
+
+    if (extra_registration_hook_) {
+      extra_registration_hook_(*server_);
+    }
 
     server_running_ = true;
     server_thread_ = std::thread([this]() {

--- a/tests/test_integration_common.h
+++ b/tests/test_integration_common.h
@@ -223,6 +223,17 @@ inline bool ssl_certs_available() {
   return cert.good() && key.good();
 }
 
+// Build a payload with index-dependent bytes. Intended for integrity tests
+// that must catch mid-stream truncation, duplication, or off-by-N corruption
+// — a uniform fill would pass a truncate-then-repad scenario.
+inline std::string make_indexed_payload(size_t n) {
+  std::string s(n, '\0');
+  for (size_t i = 0; i < n; ++i) {
+    s[i] = static_cast<char>('a' + (i % 26));
+  }
+  return s;
+}
+
 //=============================================================================
 // SSL Verification Helpers
 //=============================================================================

--- a/tests/test_integration_ssl.cc
+++ b/tests/test_integration_ssl.cc
@@ -666,25 +666,9 @@ void poison_and_echo_method(
   }
 }
 
-// Size chosen to exceed typical loopback send-buffer defaults while staying
-// cheap enough for CI. Modern kernels may still drain in one write (loopback
-// buffers auto-tune into MiB range); in that case this case becomes a
-// large-transfer smoke test rather than a back-pressure reproducer —
-// either way, mid-body corruption would surface via the content check.
+// Size exceeds typical loopback SO_SNDBUF defaults; under auto-tuned
+// buffers this degrades to a large-transfer smoke test.
 constexpr size_t kLargePayloadSize = 512 * 1024;  // 512 KiB
-
-// Fill with an index-dependent pattern so any mid-stream truncation or
-// duplication fails the byte-wise equality check at the call site. A
-// uniform fill (e.g. all 'x') would pass a truncate-then-repad scenario
-// — precisely the production corruption this test guards.
-inline std::string make_indexed_payload(size_t n)
-{
-  std::string s(n, '\0');
-  for (size_t i = 0; i < n; ++i) {
-    s[i] = static_cast<char>('a' + (i % 26));
-  }
-  return s;
-}
 
 void poison_and_bulk_echo_method(
   iqxmlrpc::Method*,
@@ -692,7 +676,7 @@ void poison_and_bulk_echo_method(
   iqxmlrpc::Value& retval)
 {
   ERR_put_error(ERR_LIB_USER, 0, 1, __FILE__, __LINE__);
-  retval = make_indexed_payload(kLargePayloadSize);
+  retval = iqxmlrpc_test::make_indexed_payload(kLargePayloadSize);
 }
 
 } // namespace
@@ -807,7 +791,8 @@ BOOST_FIXTURE_TEST_CASE(https_large_response_survives_poisoned_queue,
   BOOST_REQUIRE_MESSAGE(!r.is_fault(),
     "large-response call faulted; fault: " << r.fault_string());
 
-  const std::string expected = make_indexed_payload(kLargePayloadSize);
+  const std::string expected =
+    iqxmlrpc_test::make_indexed_payload(kLargePayloadSize);
   const std::string& actual = r.value().get_string();
   BOOST_REQUIRE_EQUAL(actual.size(), kLargePayloadSize);
   // Full byte-wise equality — catches mid-body corruption that a size-only

--- a/tests/test_integration_ssl.cc
+++ b/tests/test_integration_ssl.cc
@@ -666,11 +666,25 @@ void poison_and_echo_method(
   }
 }
 
-// Returns a payload large enough that SSL_write over a freshly-connected
-// loopback socket is likely to hit kernel-send-buffer back-pressure at
-// least once, exercising the real WANT_WRITE path in try_ssl_write. Size
-// is chosen to exceed a typical default SO_SNDBUF on Linux/macOS.
+// Size chosen to exceed typical loopback send-buffer defaults while staying
+// cheap enough for CI. Modern kernels may still drain in one write (loopback
+// buffers auto-tune into MiB range); in that case this case becomes a
+// large-transfer smoke test rather than a back-pressure reproducer —
+// either way, mid-body corruption would surface via the content check.
 constexpr size_t kLargePayloadSize = 512 * 1024;  // 512 KiB
+
+// Fill with an index-dependent pattern so any mid-stream truncation or
+// duplication fails the byte-wise equality check at the call site. A
+// uniform fill (e.g. all 'x') would pass a truncate-then-repad scenario
+// — precisely the production corruption this test guards.
+inline std::string make_indexed_payload(size_t n)
+{
+  std::string s(n, '\0');
+  for (size_t i = 0; i < n; ++i) {
+    s[i] = static_cast<char>('a' + (i % 26));
+  }
+  return s;
+}
 
 void poison_and_bulk_echo_method(
   iqxmlrpc::Method*,
@@ -678,7 +692,7 @@ void poison_and_bulk_echo_method(
   iqxmlrpc::Value& retval)
 {
   ERR_put_error(ERR_LIB_USER, 0, 1, __FILE__, __LINE__);
-  retval = std::string(kLargePayloadSize, 'x');
+  retval = make_indexed_payload(kLargePayloadSize);
 }
 
 } // namespace
@@ -769,11 +783,10 @@ BOOST_FIXTURE_TEST_CASE(https_survives_method_polluting_error_queue,
   }
 }
 
-// Large-payload variant: exercises try_ssl_write under kernel-send-buffer
-// back-pressure, which is the production repro scenario (mid-body
-// truncation of ~hundreds-of-KB responses). With the queue poisoned by
-// the method handler, any real WANT_WRITE surfacing on the reactor's
-// subsequent write call must not be misclassified as fatal.
+// Large-payload variant: drives a 512 KiB response through the reactor's
+// write path under a poisoned queue. Any mid-stream truncation, padding,
+// or corruption surfaces via the byte-wise content check — the production
+// failure mode this test is designed to catch.
 BOOST_FIXTURE_TEST_CASE(https_large_response_survives_poisoned_queue,
                         HttpsIntegrationFixture)
 {
@@ -793,15 +806,22 @@ BOOST_FIXTURE_TEST_CASE(https_large_response_survives_poisoned_queue,
 
   BOOST_REQUIRE_MESSAGE(!r.is_fault(),
     "large-response call faulted; fault: " << r.fault_string());
-  BOOST_CHECK_EQUAL(r.value().get_string().size(), kLargePayloadSize);
+
+  const std::string expected = make_indexed_payload(kLargePayloadSize);
+  const std::string& actual = r.value().get_string();
+  BOOST_REQUIRE_EQUAL(actual.size(), kLargePayloadSize);
+  // Full byte-wise equality — catches mid-body corruption that a size-only
+  // check (or uniform-fill payload) would silently pass.
+  BOOST_CHECK(actual == expected);
 }
 
-// Shutdown-with-poisoned-queue: exercises try_ssl_shutdown_nonblock,
-// including the duplicated ERR_clear_error() before the second
-// SSL_shutdown in the ret==0 branch. Without the fix, the second
-// SSL_shutdown's SSL_get_error() call would see stale queue entries.
-// We drive the shutdown by letting the client drop the connection after
-// a poisoning call; the reactor's teardown then runs the shutdown wrapper.
+// Shutdown-with-poisoned-queue: liveness guard. A client teardown following
+// a poisoning call must not leave the server in a wedged state — a second
+// fresh client must still get through. This routes the server-side shutdown
+// wrapper while the queue is dirty; whether phase-2 (SSL_shutdown ret==0)
+// is reached depends on the client's close_notify timing and is not
+// guaranteed by this test, but any server-side throw from teardown would
+// cascade into the second client's failure.
 BOOST_FIXTURE_TEST_CASE(https_shutdown_survives_poisoned_queue,
                         HttpsIntegrationFixture)
 {

--- a/tests/test_integration_ssl.cc
+++ b/tests/test_integration_ssl.cc
@@ -616,25 +616,11 @@ BOOST_FIXTURE_TEST_CASE(https_set_verify_peer_rejects_untrusted_cert, HttpsInteg
 // =============================================================================
 // Stale OpenSSL error queue regression tests
 // =============================================================================
-// SSL_get_error() consults the per-thread OpenSSL error queue in addition to
-// the I/O return value. If an unrelated earlier OpenSSL call left an entry
-// on the queue (verify callback, BIO helper, parallel connection teardown,
-// etc.), SSL_get_error() classifies a benign WANT_READ / WANT_WRITE as
-// SSL_ERROR_SSL. Before the fix, check_io_result() would translate that
-// into SslIoResult::ERROR and the reactor would throw
-// ssl::exception("SSL I/O error") mid-transfer, truncating responses.
-//
-// The contract is: every non-throwing SSL I/O wrapper calls ERR_clear_error()
-// immediately before invoking its SSL_* primitive. These tests guard that
-// contract.
-//
-// Platform note: OpenSSL 3.0+ added an internal ERR_clear_error() inside
-// SSL_do_handshake() and other high-level calls, which masks the bug at
-// runtime on modern distros. On OpenSSL 1.1.x (RHEL 8 / ubi8 CI leg)
-// that internal guard is absent and these tests fail without the fix.
-// They still exercise the wrapper code path on every platform and guard
-// against a future regression that removes ERR_clear_error() from the
-// wrappers.
+// Invariant: every SSL I/O wrapper must call ERR_clear_error() before its
+// SSL_* primitive. SSL_get_error() consults the per-thread error queue in
+// addition to the return value, so a stale entry (e.g. from a verify
+// callback) will misclassify WANT_READ / WANT_WRITE as SSL_ERROR_SSL and
+// tear the connection down mid-transfer. These tests guard that invariant.
 
 namespace {
 
@@ -680,14 +666,27 @@ void poison_and_echo_method(
   }
 }
 
+// Returns a payload large enough that SSL_write over a freshly-connected
+// loopback socket is likely to hit kernel-send-buffer back-pressure at
+// least once, exercising the real WANT_WRITE path in try_ssl_write. Size
+// is chosen to exceed a typical default SO_SNDBUF on Linux/macOS.
+constexpr size_t kLargePayloadSize = 512 * 1024;  // 512 KiB
+
+void poison_and_bulk_echo_method(
+  iqxmlrpc::Method*,
+  const iqxmlrpc::Param_list&,
+  iqxmlrpc::Value& retval)
+{
+  ERR_put_error(ERR_LIB_USER, 0, 1, __FILE__, __LINE__);
+  retval = std::string(kLargePayloadSize, 'x');
+}
+
 } // namespace
 
 // Deterministic reproducer for the wrapper's queue-hygiene contract.
-// Uses a connected AF_UNIX socketpair — enough for SSL_accept to be
-// driven off a real fd without needing an actual ClientHello. With no
-// data from the peer, SSL_accept returns -1 and SSL_get_error() should
-// report WANT_READ. A poisoned queue turns that into SSL_ERROR_SSL
-// unless the wrapper clears it first.
+// AF_UNIX socketpair drives SSL_accept off a real fd without needing a
+// real ClientHello. With no data from the peer, SSL_accept returns -1
+// and the wrapper must report WANT_READ.
 BOOST_FIXTURE_TEST_CASE(ssl_try_accept_survives_stale_error_queue,
                         HttpsIntegrationFixture)
 {
@@ -699,12 +698,20 @@ BOOST_FIXTURE_TEST_CASE(ssl_try_accept_survives_stale_error_queue,
 
   // RAII guards ensure the fds outlive the SSL object (which will call
   // SSL_free -> SSL_shutdown on the server-side fd during its destructor).
-  struct FdGuard {
-    int fd;
-    ~FdGuard() { if (fd >= 0) ::close(fd); }
+  // Non-copyable; move leaves the source in a neutral state to keep the
+  // invariant "at most one owner ever closes the fd".
+  class FdGuard {
+    int fd_;
+  public:
+    explicit FdGuard(int fd) : fd_(fd) {}
+    ~FdGuard() { if (fd_ >= 0) ::close(fd_); }
+    FdGuard(const FdGuard&) = delete;
+    FdGuard& operator=(const FdGuard&) = delete;
+    FdGuard(FdGuard&& other) noexcept : fd_(other.fd_) { other.fd_ = -1; }
+    FdGuard& operator=(FdGuard&&) = delete;
   };
-  FdGuard server_fd_guard{sv[0]};
-  FdGuard peer_fd_guard{sv[1]};
+  FdGuard server_fd_guard(sv[0]);
+  FdGuard peer_fd_guard(sv[1]);
 
   iqnet::ssl::SslIoResult result;
   {
@@ -731,13 +738,11 @@ BOOST_FIXTURE_TEST_CASE(ssl_try_accept_survives_stale_error_queue,
   ERR_clear_error();
 }
 
-// End-to-end: a method handler that poisons the per-thread OpenSSL error
-// queue must not break subsequent I/O on the same connection. Before the
-// fix, the reactor's next try_ssl_read / try_ssl_write after the handler
-// returned would misclassify would-block as fatal and tear the connection
-// down mid-response. With keep-alive, every request rides the same reactor
-// thread, so a single poisoned call silently contaminates every call that
-// follows it.
+// End-to-end guard: a method handler that pollutes the per-thread OpenSSL
+// error queue must not break subsequent SSL I/O on that thread. Under
+// Serial_executor_factory the method runs inline on the reactor thread,
+// so every try_ssl_read / try_ssl_write that follows must tolerate a
+// dirty queue.
 BOOST_FIXTURE_TEST_CASE(https_survives_method_polluting_error_queue,
                         HttpsIntegrationFixture)
 {
@@ -751,10 +756,9 @@ BOOST_FIXTURE_TEST_CASE(https_survives_method_polluting_error_queue,
   start_server(224);
   auto client = create_client();
 
-  // Multiple keep-alive calls after the first poisoning. Any would-block
-  // encountered by the reactor (e.g., between requests) will trigger the
-  // bug in the absence of the fix.
-  for (int i = 0; i < 10; ++i) {
+  // > 1 so at least one call happens after the queue has been poisoned.
+  constexpr int kKeepAliveCalls = 4;
+  for (int i = 0; i < kKeepAliveCalls; ++i) {
     const std::string payload = "poisoned_" + std::to_string(i);
     iqxmlrpc::Response r =
       client->execute("poison_and_echo", iqxmlrpc::Value(payload));
@@ -763,6 +767,73 @@ BOOST_FIXTURE_TEST_CASE(https_survives_method_polluting_error_queue,
       "call #" << i << " faulted; fault: " << r.fault_string());
     BOOST_CHECK_EQUAL(r.value().get_string(), payload);
   }
+}
+
+// Large-payload variant: exercises try_ssl_write under kernel-send-buffer
+// back-pressure, which is the production repro scenario (mid-body
+// truncation of ~hundreds-of-KB responses). With the queue poisoned by
+// the method handler, any real WANT_WRITE surfacing on the reactor's
+// subsequent write call must not be misclassified as fatal.
+BOOST_FIXTURE_TEST_CASE(https_large_response_survives_poisoned_queue,
+                        HttpsIntegrationFixture)
+{
+  BOOST_REQUIRE_MESSAGE(setup_ssl_context(),
+    "Failed to set up SSL context with embedded certificates");
+
+  extra_registration_hook_ = [](iqxmlrpc::Server& s) {
+    iqxmlrpc::register_method(s, "poison_and_bulk_echo",
+                              &poison_and_bulk_echo_method);
+  };
+
+  start_server(225);
+  auto client = create_client();
+
+  iqxmlrpc::Response r =
+    client->execute("poison_and_bulk_echo", iqxmlrpc::Value(std::string()));
+
+  BOOST_REQUIRE_MESSAGE(!r.is_fault(),
+    "large-response call faulted; fault: " << r.fault_string());
+  BOOST_CHECK_EQUAL(r.value().get_string().size(), kLargePayloadSize);
+}
+
+// Shutdown-with-poisoned-queue: exercises try_ssl_shutdown_nonblock,
+// including the duplicated ERR_clear_error() before the second
+// SSL_shutdown in the ret==0 branch. Without the fix, the second
+// SSL_shutdown's SSL_get_error() call would see stale queue entries.
+// We drive the shutdown by letting the client drop the connection after
+// a poisoning call; the reactor's teardown then runs the shutdown wrapper.
+BOOST_FIXTURE_TEST_CASE(https_shutdown_survives_poisoned_queue,
+                        HttpsIntegrationFixture)
+{
+  BOOST_REQUIRE_MESSAGE(setup_ssl_context(),
+    "Failed to set up SSL context with embedded certificates");
+
+  extra_registration_hook_ = [](iqxmlrpc::Server& s) {
+    iqxmlrpc::register_method(s, "poison_and_echo", &poison_and_echo_method);
+  };
+
+  start_server(226);
+
+  {
+    auto client = create_client();
+    // keep-alive off: the server-side connection will go through shutdown
+    // right after the response is sent, on a reactor thread that just had
+    // its error queue poisoned by the method handler.
+    client->set_keep_alive(false);
+
+    iqxmlrpc::Response r =
+      client->execute("poison_and_echo", iqxmlrpc::Value(std::string("x")));
+    BOOST_REQUIRE(!r.is_fault());
+  }
+
+  // A second call must still succeed — if the server's shutdown path
+  // tripped on the poisoned queue it would have logged/thrown internally
+  // and may have poisoned state visible to the next handshake.
+  auto client2 = create_client();
+  iqxmlrpc::Response r2 =
+    client2->execute("poison_and_echo", iqxmlrpc::Value(std::string("y")));
+  BOOST_REQUIRE(!r2.is_fault());
+  BOOST_CHECK_EQUAL(r2.value().get_string(), "y");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_integration_ssl.cc
+++ b/tests/test_integration_ssl.cc
@@ -6,12 +6,16 @@
 #include <boost/test/unit_test.hpp>
 
 #include <string>
+#include <sys/socket.h>
+#include <unistd.h>
 
 #include "libiqxmlrpc/libiqxmlrpc.h"
 #include "libiqxmlrpc/https_server.h"
 #include "libiqxmlrpc/https_client.h"
+#include "libiqxmlrpc/ssl_connection.h"
 #include "libiqxmlrpc/ssl_lib.h"
 
+#include <openssl/err.h>
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
 
@@ -607,6 +611,158 @@ BOOST_FIXTURE_TEST_CASE(https_set_verify_peer_rejects_untrusted_cert, HttpsInteg
   BOOST_CHECK_THROW(
     client->execute("echo", Value("should fail")),
     std::exception);
+}
+
+// =============================================================================
+// Stale OpenSSL error queue regression tests
+// =============================================================================
+// SSL_get_error() consults the per-thread OpenSSL error queue in addition to
+// the I/O return value. If an unrelated earlier OpenSSL call left an entry
+// on the queue (verify callback, BIO helper, parallel connection teardown,
+// etc.), SSL_get_error() classifies a benign WANT_READ / WANT_WRITE as
+// SSL_ERROR_SSL. Before the fix, check_io_result() would translate that
+// into SslIoResult::ERROR and the reactor would throw
+// ssl::exception("SSL I/O error") mid-transfer, truncating responses.
+//
+// The contract is: every non-throwing SSL I/O wrapper calls ERR_clear_error()
+// immediately before invoking its SSL_* primitive. These tests guard that
+// contract.
+//
+// Platform note: OpenSSL 3.0+ added an internal ERR_clear_error() inside
+// SSL_do_handshake() and other high-level calls, which masks the bug at
+// runtime on modern distros. On OpenSSL 1.1.x (RHEL 8 / ubi8 CI leg)
+// that internal guard is absent and these tests fail without the fix.
+// They still exercise the wrapper code path on every platform and guard
+// against a future regression that removes ERR_clear_error() from the
+// wrappers.
+
+namespace {
+
+// Helper: poison the thread-local OpenSSL error queue with a synthetic
+// non-syscall entry. ERR_LIB_USER (!= ERR_LIB_SYS) forces SSL_get_error()
+// to return SSL_ERROR_SSL when the subsequent SSL_* call returns <= 0,
+// regardless of the real I/O state.
+void poison_openssl_error_queue()
+{
+  ERR_clear_error();
+  BOOST_REQUIRE_EQUAL(ERR_peek_error(), 0UL);
+  ERR_put_error(ERR_LIB_USER, 0, 1, __FILE__, __LINE__);
+  BOOST_REQUIRE_NE(ERR_peek_error(), 0UL);
+}
+
+// Exposes the protected non-throwing wrappers and lets a test switch the
+// underlying socket to non-blocking mode.
+class StaleQueueSslHelper : public iqnet::ssl::Connection {
+public:
+  explicit StaleQueueSslHelper(const iqnet::Socket& s)
+    : iqnet::ssl::Connection(s) {}
+
+  using iqnet::ssl::Connection::try_ssl_accept_nonblock;
+  using iqnet::ssl::Connection::try_ssl_read;
+
+  void enable_nonblocking() { sock.set_non_blocking(true); }
+};
+
+// Test method: pollutes the per-thread OpenSSL error queue, then echoes.
+// Under Serial_executor_factory the method runs on the reactor thread, so
+// the subsequent try_ssl_write / try_ssl_read in the reactor observes the
+// poisoned queue — the exact scenario the fix must survive.
+void poison_and_echo_method(
+  iqxmlrpc::Method*,
+  const iqxmlrpc::Param_list& args,
+  iqxmlrpc::Value& retval)
+{
+  ERR_put_error(ERR_LIB_USER, 0, 1, __FILE__, __LINE__);
+  if (!args.empty()) {
+    retval = args[0];
+  } else {
+    retval = std::string();
+  }
+}
+
+} // namespace
+
+// Deterministic reproducer for the wrapper's queue-hygiene contract.
+// Uses a connected AF_UNIX socketpair — enough for SSL_accept to be
+// driven off a real fd without needing an actual ClientHello. With no
+// data from the peer, SSL_accept returns -1 and SSL_get_error() should
+// report WANT_READ. A poisoned queue turns that into SSL_ERROR_SSL
+// unless the wrapper clears it first.
+BOOST_FIXTURE_TEST_CASE(ssl_try_accept_survives_stale_error_queue,
+                        HttpsIntegrationFixture)
+{
+  BOOST_REQUIRE_MESSAGE(setup_ssl_context(),
+    "Failed to set up SSL context with embedded certificates");
+
+  int sv[2] = { -1, -1 };
+  BOOST_REQUIRE_EQUAL(::socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0);
+
+  // RAII guards ensure the fds outlive the SSL object (which will call
+  // SSL_free -> SSL_shutdown on the server-side fd during its destructor).
+  struct FdGuard {
+    int fd;
+    ~FdGuard() { if (fd >= 0) ::close(fd); }
+  };
+  FdGuard server_fd_guard{sv[0]};
+  FdGuard peer_fd_guard{sv[1]};
+
+  iqnet::ssl::SslIoResult result;
+  {
+    iqnet::Socket server_side(sv[0], iqnet::Inet_addr("127.0.0.1", 0));
+    StaleQueueSslHelper server_conn(server_side);
+    server_conn.enable_nonblocking();
+
+    poison_openssl_error_queue();
+
+    // No ClientHello pending on the peer end -> SSL_accept returns -1 with
+    // WANT_READ under a clean queue, ERROR under a poisoned queue (the bug).
+    result = server_conn.try_ssl_accept_nonblock();
+    // server_conn/server_side destruct here, SSL_free runs while sv[0] is
+    // still open. The FdGuards then close the fds.
+  }
+
+  BOOST_CHECK_MESSAGE(
+    result == iqnet::ssl::SslIoResult::WANT_READ,
+    "Expected WANT_READ from try_ssl_accept_nonblock(); got "
+      << static_cast<int>(result)
+      << ". Stale-error-queue regression: wrapper did not call "
+         "ERR_clear_error() before SSL_accept().");
+
+  ERR_clear_error();
+}
+
+// End-to-end: a method handler that poisons the per-thread OpenSSL error
+// queue must not break subsequent I/O on the same connection. Before the
+// fix, the reactor's next try_ssl_read / try_ssl_write after the handler
+// returned would misclassify would-block as fatal and tear the connection
+// down mid-response. With keep-alive, every request rides the same reactor
+// thread, so a single poisoned call silently contaminates every call that
+// follows it.
+BOOST_FIXTURE_TEST_CASE(https_survives_method_polluting_error_queue,
+                        HttpsIntegrationFixture)
+{
+  BOOST_REQUIRE_MESSAGE(setup_ssl_context(),
+    "Failed to set up SSL context with embedded certificates");
+
+  extra_registration_hook_ = [](iqxmlrpc::Server& s) {
+    iqxmlrpc::register_method(s, "poison_and_echo", &poison_and_echo_method);
+  };
+
+  start_server(224);
+  auto client = create_client();
+
+  // Multiple keep-alive calls after the first poisoning. Any would-block
+  // encountered by the reactor (e.g., between requests) will trigger the
+  // bug in the absence of the fix.
+  for (int i = 0; i < 10; ++i) {
+    const std::string payload = "poisoned_" + std::to_string(i);
+    iqxmlrpc::Response r =
+      client->execute("poison_and_echo", iqxmlrpc::Value(payload));
+
+    BOOST_REQUIRE_MESSAGE(!r.is_fault(),
+      "call #" << i << " faulted; fault: " << r.fault_string());
+    BOOST_CHECK_EQUAL(r.value().get_string(), payload);
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

- Fixes intermittent mid-response truncation on HTTPS responses caused by a stale OpenSSL error queue being misread by `SSL_get_error()` as `SSL_ERROR_SSL` (see `LIBIQXMLRPC_0_14_x_STALE_ERROR_QUEUE_BUG.md`). Root cause: the non-throwing SSL wrappers added in 0.14.x (PR #62) lost the implicit queue-draining side-effect the 0.13.x exception path had.
- Adds `ERR_clear_error()` before every `SSL_*` call in both the non-throwing reactor-path wrappers (`try_ssl_read`/`try_ssl_write`/`try_ssl_accept_nonblock`/`try_ssl_connect_nonblock`/`try_ssl_shutdown_nonblock`) and the blocking wrappers (`ssl_accept`/`ssl_connect`/`shutdown`/`send`/`recv`). All 9 inline call sites carry the byte-identical one-liner rationale.
- Routes `try_ssl_shutdown_nonblock`'s second `SSL_shutdown` through `check_io_result()` instead of silently discarding its return value, and fixes a connection-stranding bug in `Reaction_connection::switch_state()` where `CONNECTION_CLOSE` from the SHUTDOWN state failed to signal `terminate`.
- Fixes a latent partial-write silent-truncation in `switch_state`'s WRITING branch — now advances `send_buf`/`buf_len` and re-registers `WANT_WRITE` instead of coercing to OK.
- Adds four targeted tests: unit-level `ssl_try_accept_survives_stale_error_queue` (deterministic reproducer over AF_UNIX socketpair), end-to-end `https_survives_method_polluting_error_queue`, `https_large_response_survives_poisoned_queue` (512 KiB with index-dependent byte-wise integrity check), and `https_shutdown_survives_poisoned_queue` (liveness guard across teardown).

## Test plan

- [x] `make check` — 21/21 tests passing, 29 ssl_tests cases, 0 failures
- [x] No compiler warnings on clang 16 (macOS)
- [x] No ABI changes (public symbol count unchanged; comments + internal call additions only)
- [x] `ssl_try_accept_survives_stale_error_queue` fails without the fix on OpenSSL 1.1.x (reproducer); passes on 3.0+ which clears the queue internally
- [x] Byte-wise integrity check on 512 KiB round-trip catches mid-body corruption that a size-only assertion would miss
- [ ] CI: ubuntu-24.04 / ubi8 / macos / ASan/UBSan / TSan / Valgrind / Fuzz / coverage / cppcheck / clang-tidy / CodeQL / Benchmark

## Review history

This PR went through four review rounds via the `pr-review-toolkit`, involving six specialist reviewers (code, comments, tests, silent failures, type design, simplification). Every finding across all rounds is closed. Commit breakdown:

- `7244bf1` — initial fix + 2 tests
- `b4fd096` — R1: extend to blocking wrappers, harden `FdGuard`, fix partial-write + second `SSL_shutdown`, comment cleanup
- `3a38f7c` — R2: demote phase-2 ERROR to `CONNECTION_CLOSE`, indexed-byte integrity check
- `04159c6` — R3: fix `CONNECTION_CLOSE` stranding in SHUTDOWN state, hoist `make_indexed_payload` to shared header

## Not in this PR (follow-up candidates)

- Unit-level test for the phase-2 `CONNECTION_CLOSE` demotion (requires BIO injection / SSL mocking — meaningful engineering lift for a low-probability event; indirectly exercised by the `switch_state` fix).