### PR TITLE
Release 0.14.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(Libiqxmlrpc)
-set(Libiqxmlrpc_VERSION 0.14.2)
+set(Libiqxmlrpc_VERSION 0.14.3)
 
 # Require C++17 standard for entire project
 set(CMAKE_CXX_STANDARD 17)

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,46 @@
 Look into ChangeLog file for full list of changes.
 
+0.14.2 - 0.14.3
+  Bug Fixes:
+    * Fix intermittent mid-response truncation on HTTPS caused by a stale
+      per-thread OpenSSL error queue misclassifying WANT_READ/WANT_WRITE
+      as SSL_ERROR_SSL (PR #258). Regression from the 0.14.x non-throwing
+      SSL I/O fast path (PR #62) which dropped the implicit queue-draining
+      side-effect of the 0.13.x exception-based path. Most observable on
+      OpenSSL 1.1.x; OpenSSL 3.0+ clears the queue internally inside
+      SSL_do_handshake / SSL_read / etc. and masked the defect at runtime.
+    * Fix connection stranding when the reactor SHUTDOWN state received
+      CONNECTION_CLOSE: switch_state() now terminates on both OK and
+      CONNECTION_CLOSE, matching reg_shutdown()'s "both flags set"
+      fixed-point.
+    * Fix silent partial-write drop in the non-blocking reactor WRITING
+      branch: switch_state() now advances send_buf / buf_len and
+      re-registers WANT_WRITE instead of coercing partial completions to
+      OK. Dormant by default (SSL_MODE_ENABLE_PARTIAL_WRITE is not set)
+      but defends against silent truncation if the mode is ever enabled.
+    * Surface real phase-2 SSL_shutdown errors via CONNECTION_CLOSE
+      instead of silently discarding the second SSL_shutdown's return
+      value.
+
+  Hardening:
+    * Add ERR_clear_error() before every SSL_* call in both the
+      non-throwing reactor-path wrappers (try_ssl_read / try_ssl_write /
+      try_ssl_accept_nonblock / try_ssl_connect_nonblock /
+      try_ssl_shutdown_nonblock) and the blocking wrappers (ssl_accept,
+      ssl_connect, shutdown, send, recv). Follows the explicit
+      SSL_get_error(3) contract that the thread's error queue must be
+      empty before a TLS I/O call.
+
+  Test Coverage:
+    * Deterministic unit-level reproducer for the stale-queue bug
+      (ssl_try_accept_survives_stale_error_queue) — AF_UNIX socketpair
+      with poisoned queue drives try_ssl_accept_nonblock.
+    * End-to-end poisoned-queue integration tests with a running HTTPS
+      server (keep-alive, large-response byte-wise integrity over
+      512 KiB, shutdown liveness guard).
+    * Shared make_indexed_payload helper in test_integration_common.h
+      for any future test that needs truncation-detecting payloads.
+
 0.14.1 - 0.14.2
   Security Fixes:
     * Fix client-side TLS certificate validation disabled by default (CWE-295)


### PR DESCRIPTION
## Summary

Bugfix release for the 0.14.x series. Primary fix is [#258](https://github.com/yarikmsu/libiqxmlrpc/pull/258) — mid-response truncation on HTTPS caused by a stale per-thread OpenSSL error queue. Secondary hardening covers three pre-existing latent defects surfaced during review.

## Changelog (0.14.2 → 0.14.3)

### Bug Fixes
- **Stale OpenSSL error queue → mid-response truncation on HTTPS.** 0.14.x non-throwing SSL fast path (#62) dropped the implicit queue-draining side-effect of the 0.13.x exception path; `SSL_get_error()` then misclassified `WANT_READ` / `WANT_WRITE` as `SSL_ERROR_SSL` and tore down connections mid-transfer. Fix: `ERR_clear_error()` before every `SSL_*` call per the `SSL_get_error(3)` contract. Reproducible on OpenSSL 1.1.x (RHEL 8 / `ubi8` CI leg); masked on OpenSSL 3.0+ which clears the queue internally inside `SSL_do_handshake` / `SSL_read`.
- **Reactor SHUTDOWN connection stranding.** `switch_state()` now treats `CONNECTION_CLOSE` as terminal (matches `OK`), preventing orphaned fds when `reg_shutdown()` takes its "both flags set" fixed-point branch.
- **Silent partial-write drop in non-blocking WRITING branch.** `send_buf` / `buf_len` now advance and `WANT_WRITE` is re-registered instead of coercing partial to OK. Dormant-by-default (`SSL_MODE_ENABLE_PARTIAL_WRITE` not set).
- **Phase-2 `SSL_shutdown` return now inspected.** Real errors surface via `CONNECTION_CLOSE` instead of being silently discarded.

### Hardening
- `ERR_clear_error()` added before every `SSL_*` call in both the non-throwing wrappers (`try_ssl_read` / `try_ssl_write` / `try_ssl_accept_nonblock` / `try_ssl_connect_nonblock` / `try_ssl_shutdown_nonblock`) and the blocking wrappers (`ssl_accept` / `ssl_connect` / `shutdown` / `send` / `recv`).

### Test Coverage
- `ssl_try_accept_survives_stale_error_queue` — deterministic AF_UNIX socketpair reproducer (fails without the fix on OpenSSL 1.1.x).
- `https_survives_method_polluting_error_queue` — keep-alive RPCs under a poisoning method handler.
- `https_large_response_survives_poisoned_queue` — 512 KiB response with index-dependent byte-wise integrity check.
- `https_shutdown_survives_poisoned_queue` — liveness guard across teardown + fresh client.
- Shared `make_indexed_payload()` in `test_integration_common.h`.

### CI / Build (internal)
Dependabot bumps merged during the cycle (not user-facing; included in the release window):
- `codecov/codecov-action` 5 → 6 (#255)
- `actions/upload-artifact` 6.0.0 → 7.0.1 (#257)
- `actions/github-script` 8.0.0 → 9.0.0 (#256)

## No ABI change

Library symbol count unchanged — internal-only additions (no new public API, no header changes that cross the ABI boundary).

## Review history

Main PR #258 went through **4 review rounds + code-simplifier** via the pr-review-toolkit (code-reviewer, comment-analyzer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer). All findings closed. Commit-level trail preserved in the merge commit for future archeology.

## Test plan

- [x] `make check` — 21/21 passing, 29 ssl_tests cases
- [x] No warnings on clang 16 (macOS OpenSSL 3.6)
- [x] Merged master verified before branching
- [ ] CI on this release PR: ubuntu-24.04 / ubi8 / macos / ASan/UBSan / TSan / Valgrind / Fuzz / coverage / cppcheck / clang-tidy / CodeQL / Benchmark

## Post-merge steps (per docs/PROJECT_RULES.md)

After this PR merges on master:
1. `git tag -a 0.14.3 -m "Release 0.14.3"` on the merge commit
2. `git push origin 0.14.3`
3. `gh release create 0.14.3 --title "0.14.3" --notes "..."`